### PR TITLE
[db] platformname column (profile name) from 10->50 length. Fixes #9

### DIFF
--- a/database/objects.py
+++ b/database/objects.py
@@ -140,7 +140,7 @@ class Game(Base):
 class Player(Base):
     __tablename__ = 'players'
     platformid = Column(String(40), primary_key=True)
-    platformname = Column(String(10))
+    platformname = Column(String(50))
     avatar = Column(String(150))
     ranks = Column(postgresql.ARRAY(Integer, dimensions=1))  # foreign key
     games = relationship('PlayerGame')


### PR DESCRIPTION
Note: When merged, for local dev the database either needs to be recreated or column modified since SQLAlchemy doesn't have automatic migration support out of the box.

Manual modification snippet for local and fit for a prod database: Transaction keeps the table from locking.

```sql
BEGIN;
  ALTER TABLE "saltie"."players" ALTER COLUMN "platformname" TYPE varchar(50);
COMMIT;
```

In another RFC issue or in discord I'll mention the migration handling options and my past experiences with them since this usually gets old really fast, especially as more team members join. :)
