### PR TITLE
Rename parsed replays by id

### DIFF
--- a/backend/tasks/celery_tasks.py
+++ b/backend/tasks/celery_tasks.py
@@ -120,6 +120,8 @@ def parse_replay_task(self, fn):
     sess.commit()
     sess.close()
     shutil.move(fn, os.path.join(os.path.dirname(fn), g.game_metadata.id + '.replay'))
+    shutil.move(pickled + '.pts', os.path.join(os.path.dirname(pickled), g.game_metadata.id + '.replay.pts'))
+    shutil.move(pickled + '.gzip', os.path.join(os.path.dirname(pickled), g.game_metadata.id + '.replay.gzip'))
 
 
 @celery.task(base=DBTask, bind=True, priority=9)


### PR DESCRIPTION
Fixes an issue where parsed replay files are not named by the game id.

Currently:
Upload `a.replay` ->
`data/rlreplays/id_.replay`
`data/parsed/a.replay.gzip`
`data/parsed/a.replay.pts`

Fixed:
Upload `a.replay` ->
`data/rlreplays/id_.replay`
`data/parsed/id_.replay.gzip`
`data/parsed/id_.replay.pts`