### PR TITLE
New basic stats math

### DIFF
--- a/backend/blueprints/spa_api/service_layers/replay/basic_stats.py
+++ b/backend/blueprints/spa_api/service_layers/replay/basic_stats.py
@@ -1,11 +1,13 @@
 from enum import auto, Enum
-from typing import List, cast
+from typing import List
 
 from flask import current_app
+from sqlalchemy import func
 
 from backend.database.objects import Game, PlayerGame
+from backend.database.wrapper.player_wrapper import PlayerWrapper
+from backend.database.wrapper.stats.player_stat_wrapper import PlayerStatWrapper
 from ..chart_data import ChartData, ChartDataPoint
-from ..utils import sort_player_games_by_team_then_id
 from ...errors.errors import ReplayNotFound
 
 
@@ -37,53 +39,53 @@ Metadata = BasicStatsMetadata
 
 basic_stats_metadatas = [
     # Hits
-    Metadata('total_hits', ChartType.radar, SubCat.Hits),
-    Metadata('average_hit_distance', ChartType.radar, SubCat.Hits),
-    Metadata('ball_hit_forward', ChartType.bar, SubCat.Hits),
-    Metadata('total_dribbles', ChartType.bar, SubCat.Hits),
-    Metadata('total_passes', ChartType.bar, SubCat.Hits),
-    Metadata('total_aerials', ChartType.bar, SubCat.Hits),
+    Metadata('hits', ChartType.radar, SubCat.Hits),
+    Metadata('avg hit dist', ChartType.radar, SubCat.Hits),
+    Metadata('ball hit forward', ChartType.bar, SubCat.Hits),
+    Metadata('dribbles', ChartType.bar, SubCat.Hits),
+    Metadata('passes', ChartType.bar, SubCat.Hits),
+    Metadata('aerials', ChartType.bar, SubCat.Hits),
 
     # Ball
-    Metadata('time_close_to_ball', ChartType.radar, SubCat.Ball),
-    Metadata('time_closest_to_ball', ChartType.pie, SubCat.Ball),
-    Metadata('time_furthest_from_ball', ChartType.pie, SubCat.Ball),
-    Metadata('time_behind_ball', ChartType.radar, SubCat.Ball),
-    Metadata('time_in_front_ball', ChartType.radar, SubCat.Ball),
+    Metadata('time close to ball', ChartType.radar, SubCat.Ball),
+    Metadata('time closest to ball', ChartType.pie, SubCat.Ball),
+    Metadata('time furthest from ball', ChartType.pie, SubCat.Ball),
+    Metadata('time behind ball', ChartType.radar, SubCat.Ball),
+    Metadata('time in front ball', ChartType.radar, SubCat.Ball),
 
     # Positioning
-    Metadata('time_high_in_air', ChartType.radar, SubCat.Positioning),
-    Metadata('time_low_in_air', ChartType.radar, SubCat.Positioning),
-    Metadata('time_on_ground', ChartType.radar, SubCat.Positioning),
-    Metadata('time_in_defending_third', ChartType.radar, SubCat.Positioning),
-    Metadata('time_in_neutral_third', ChartType.radar, SubCat.Positioning),
-    Metadata('time_in_attacking_third', ChartType.radar, SubCat.Positioning),
-    Metadata('time_in_defending_half', ChartType.radar, SubCat.Positioning),
-    Metadata('time_in_attacking_half', ChartType.radar, SubCat.Positioning),
+    Metadata('time high in air', ChartType.radar, SubCat.Positioning),
+    Metadata('time low in air', ChartType.radar, SubCat.Positioning),
+    Metadata('time on ground', ChartType.radar, SubCat.Positioning),
+    Metadata('time in defending third', ChartType.radar, SubCat.Positioning),
+    Metadata('time in neutral third', ChartType.radar, SubCat.Positioning),
+    Metadata('time in attacking third', ChartType.radar, SubCat.Positioning),
+    Metadata('time in defending half', ChartType.radar, SubCat.Positioning),
+    Metadata('time in attacking half', ChartType.radar, SubCat.Positioning),
 
     # playstyles
-    Metadata('average_speed', ChartType.radar, SubCat.Playstyles),
-    Metadata('time_at_boost_speed', ChartType.radar, SubCat.Playstyles),
-    Metadata('time_at_slow_speed', ChartType.radar, SubCat.Playstyles),
-    Metadata('time_at_super_sonic', ChartType.radar, SubCat.Playstyles),
+    Metadata('speed', ChartType.radar, SubCat.Playstyles),
+    Metadata('time at boost speed', ChartType.radar, SubCat.Playstyles),
+    Metadata('time at slow speed', ChartType.radar, SubCat.Playstyles),
+    Metadata('time at super sonic', ChartType.radar, SubCat.Playstyles),
 
     # Positioning
-    Metadata('possession_time', ChartType.pie, SubCat.Possession),
+    Metadata('possession', ChartType.pie, SubCat.Possession),
     Metadata('turnovers', ChartType.bar, SubCat.Possession),
-    Metadata('turnovers_on_my_half', ChartType.bar, SubCat.Possession),
-    Metadata('turnovers_on_their_half', ChartType.bar, SubCat.Possession),
+    Metadata('turnovers on my half', ChartType.bar, SubCat.Possession),
+    Metadata('turnovers on their half', ChartType.bar, SubCat.Possession),
 
     # boost
-    Metadata('boost_usage', ChartType.radar, SubCat.Boosts),
-    Metadata('wasted_collection', ChartType.radar, SubCat.Boosts),
-    Metadata('wasted_usage', ChartType.radar, SubCat.Boosts),
-    Metadata('num_small_boosts', ChartType.bar, SubCat.Boosts),
-    Metadata('num_large_boosts', ChartType.bar, SubCat.Boosts),
-    Metadata('num_stolen_boosts', ChartType.bar, SubCat.Boosts),
-    Metadata('time_full_boost', ChartType.radar, SubCat.Boosts),
-    Metadata('time_low_boost', ChartType.radar, SubCat.Boosts),
-    Metadata('time_no_boost', ChartType.radar, SubCat.Boosts),
-    Metadata('boost_ratio', ChartType.bar, SubCat.Boosts),
+    Metadata('boost usage', ChartType.radar, SubCat.Boosts),
+    Metadata('wasted collection', ChartType.radar, SubCat.Boosts),
+    Metadata('wasted usage', ChartType.radar, SubCat.Boosts),
+    Metadata('num small boosts', ChartType.bar, SubCat.Boosts),
+    Metadata('num large boosts', ChartType.bar, SubCat.Boosts),
+    Metadata('num stolen boosts', ChartType.bar, SubCat.Boosts),
+    Metadata('time full boost', ChartType.radar, SubCat.Boosts),
+    Metadata('time low boost', ChartType.radar, SubCat.Boosts),
+    Metadata('time no boost', ChartType.radar, SubCat.Boosts),
+    Metadata('boost ratio', ChartType.bar, SubCat.Boosts),
 
     # efficiency
     Metadata('collection boost efficiency', ChartType.bar, SubCat.Efficiency),
@@ -92,8 +94,10 @@ basic_stats_metadatas = [
     Metadata('turnover efficiency', ChartType.bar, SubCat.Efficiency),
     Metadata('shot %', ChartType.bar, SubCat.Efficiency),
     Metadata('useful/hits', ChartType.radar, SubCat.Efficiency),
-    Metadata('aerial_efficiency', ChartType.radar, SubCat.Efficiency),
+    Metadata('aerial efficiency', ChartType.radar, SubCat.Efficiency),
 ]
+pw = PlayerWrapper()
+wrapper = PlayerStatWrapper(pw)
 
 
 class StatDataPoint(ChartDataPoint):
@@ -112,22 +116,40 @@ class BasicStatChartData(ChartData):
     def create_from_id(id_: str) -> List['BasicStatChartData']:
         session = current_app.config['db']()
         game: Game = session.query(Game).filter(Game.hash == id_).first()
+        # this is weird because we need to do aggregate
+        playergames: List = session.query(func.max(PlayerGame.id), func.bool_and(PlayerGame.is_orange),
+                                          func.max(PlayerGame.name),
+                                          *wrapper.individual_query).filter(
+            PlayerGame.game == id_).group_by(PlayerGame.player).all()
+        wrapped_playergames: List[dict] = [{**{
+            'id': playergame[0],
+            'is orange': playergame[1],
+            'name': playergame[2]
+        }, **wrapper.get_wrapped_stats(playergame[2:])}
+                                           for playergame in playergames]
         if game is None:
             raise ReplayNotFound()
-
+        print(wrapped_playergames[0])
         all_chart_data = []
         for basic_stats_metadata in basic_stats_metadatas:
+            datapoints = []
+            for player_game in sorted(sorted(wrapped_playergames, key=lambda x: x['is orange']), key=lambda x: x['id']):
+                if basic_stats_metadata.stat_name in player_game:
+                    value = float(player_game[basic_stats_metadata.stat_name])
+                elif hasattr(player_game, basic_stats_metadata.stat_name):
+                    value = getattr(player_game, basic_stats_metadata.stat_name)
+                else:
+                    value = 0.0
+                point = StatDataPoint(
+                    name=player_game['name'],
+                    value=value,
+                    is_orange=player_game['is orange']
+                )
+                datapoints.append(point)
+
             chart_data = BasicStatChartData(
                 title=basic_stats_metadata.stat_name,
-                chart_data_points=[
-                    StatDataPoint(
-                        name=player_game.name,
-                        value=getattr(player_game, basic_stats_metadata.stat_name),
-                        is_orange=player_game.is_orange
-                    )
-                    for player_game in sort_player_games_by_team_then_id(
-                        cast(List[PlayerGame], game.playergames))
-                ],
+                chart_data_points=datapoints,
                 type_=basic_stats_metadata.type,
                 subcategory=basic_stats_metadata.subcategory
             )

--- a/backend/blueprints/spa_api/service_layers/replay/basic_stats.py
+++ b/backend/blueprints/spa_api/service_layers/replay/basic_stats.py
@@ -90,8 +90,8 @@ basic_stats_metadatas = [
     # efficiency
     Metadata('collection boost efficiency', ChartType.bar, SubCat.Efficiency),
     Metadata('used boost efficiency', ChartType.bar, SubCat.Efficiency),
-    Metadata('total boost efficiency', ChartType.bar, SubCat.Efficiency),
-    Metadata('turnover efficiency', ChartType.bar, SubCat.Efficiency),
+    Metadata('total boost efficiency', ChartType.radar, SubCat.Efficiency),
+    Metadata('turnover efficiency', ChartType.radar, SubCat.Efficiency),
     Metadata('shot %', ChartType.bar, SubCat.Efficiency),
     Metadata('useful/hits', ChartType.radar, SubCat.Efficiency),
     Metadata('aerial efficiency', ChartType.radar, SubCat.Efficiency),

--- a/backend/blueprints/spa_api/service_layers/replay/basic_stats.py
+++ b/backend/blueprints/spa_api/service_layers/replay/basic_stats.py
@@ -139,8 +139,6 @@ class BasicStatChartData(ChartData):
             for player_game in wrapped_playergames:
                 if basic_stats_metadata.stat_name in player_game:
                     value = float(player_game[basic_stats_metadata.stat_name])
-                elif hasattr(player_game, basic_stats_metadata.stat_name):
-                    value = getattr(player_game, basic_stats_metadata.stat_name)
                 else:
                     value = 0.0
                 point = StatDataPoint(

--- a/backend/blueprints/spa_api/service_layers/replay/basic_stats.py
+++ b/backend/blueprints/spa_api/service_layers/replay/basic_stats.py
@@ -121,19 +121,22 @@ class BasicStatChartData(ChartData):
                                           func.max(PlayerGame.name),
                                           *wrapper.individual_query).filter(
             PlayerGame.game == id_).group_by(PlayerGame.player).all()
-        wrapped_playergames: List[dict] = [{**{
-            'id': playergame[0],
-            'is orange': playergame[1],
-            'name': playergame[2]
-        }, **wrapper.get_wrapped_stats(playergame[2:])}
-                                           for playergame in playergames]
+        wrapped_playergames: List[dict] = [{
+            **{
+                'id': playergame[0],
+                'is orange': playergame[1],
+                'name': playergame[2]
+            },
+            **wrapper.get_wrapped_stats(playergame[2:])}
+            for playergame in playergames]
         if game is None:
             raise ReplayNotFound()
         print(wrapped_playergames[0])
         all_chart_data = []
+        wrapped_playergames = sorted(sorted(wrapped_playergames, key=lambda x: x['id']), key=lambda x: x['is orange'])
         for basic_stats_metadata in basic_stats_metadatas:
             datapoints = []
-            for player_game in sorted(sorted(wrapped_playergames, key=lambda x: x['is orange']), key=lambda x: x['id']):
+            for player_game in wrapped_playergames:
                 if basic_stats_metadata.stat_name in player_game:
                     value = float(player_game[basic_stats_metadata.stat_name])
                 elif hasattr(player_game, basic_stats_metadata.stat_name):

--- a/backend/database/wrapper/field_wrapper.py
+++ b/backend/database/wrapper/field_wrapper.py
@@ -5,7 +5,7 @@ from backend.database.utils.dynamic_field_manager import DynamicFieldResult
 
 class FieldExplanation:
     def __init__(self, field_name: str, simple_explanation: str,
-                 field_rename: str=None, math_explanation: str=None, file_creation: str=None):
+                 field_rename: str = None, math_explanation: str = None, file_creation: str = None):
         self.field_rename = field_rename
         self.field_name = field_name
         self.simple_explanation = simple_explanation
@@ -15,7 +15,7 @@ class FieldExplanation:
 
 class QueryFieldWrapper:
     def __init__(self, query: any, dynamic_field: DynamicFieldResult,
-                 explanation: FieldExplanation=None, is_percent=False, is_boolean=False, is_cumulative=False):
+                 explanation: FieldExplanation = None, is_percent=False, is_boolean=False, is_cumulative=False):
         self.is_cumulative = is_cumulative
         self.is_boolean = is_boolean
         self.is_percent = is_percent
@@ -37,14 +37,17 @@ class QueryFieldWrapper:
             return self.dynamic_field.field_name
 
 
-def get_explanations(dynamic_field_list) ->(Dict[str, FieldExplanation], List[FieldExplanation]):
+def get_explanations(dynamic_field_list) -> (Dict[str, FieldExplanation], List[FieldExplanation]):
     field_list = [
         FieldExplanation('possession_time', 'Duration the ball was last touched by player', field_rename='possession'),
         FieldExplanation('average_speed', 'The average speed of the player in a game', field_rename='speed'),
         FieldExplanation('total_passes', 'Total passes that took place in a game', field_rename='passes'),
         FieldExplanation('total_hits', 'Total number of hits that took place in a game', field_rename='hits'),
         FieldExplanation('total_aerials', 'Total number of aerials that took place in a game', field_rename='aerials'),
-        FieldExplanation('average_hit_distance', 'Total number of aerials that took place in a game', field_rename='avg hit dist'),
+        FieldExplanation('total_dribbles', 'Total number of dribbles that took place in a game',
+                         field_rename='dribbles'),
+        FieldExplanation('average_hit_distance', 'Total number of aerials that took place in a game',
+                         field_rename='avg hit dist'),
     ]
     explanation_map = dict()
     for field in field_list:

--- a/backend/database/wrapper/field_wrapper.py
+++ b/backend/database/wrapper/field_wrapper.py
@@ -46,7 +46,8 @@ def get_explanations(dynamic_field_list) -> (Dict[str, FieldExplanation], List[F
         FieldExplanation('total_aerials', 'Total number of aerials that took place in a game', field_rename='aerials'),
         FieldExplanation('total_dribbles', 'Total number of dribbles that took place in a game',
                          field_rename='dribbles'),
-        FieldExplanation('average_hit_distance', 'Total number of aerials that took place in a game',
+        FieldExplanation('average_hit_distance',
+                         'Average distance the ball went after being hit before being touched by another player',
                          field_rename='avg hit dist'),
     ]
     explanation_map = dict()

--- a/backend/database/wrapper/field_wrapper.py
+++ b/backend/database/wrapper/field_wrapper.py
@@ -49,6 +49,9 @@ def get_explanations(dynamic_field_list) -> (Dict[str, FieldExplanation], List[F
         FieldExplanation('average_hit_distance',
                          'Average distance the ball went after being hit before being touched by another player',
                          field_rename='avg hit dist'),
+        FieldExplanation('useful hits',
+                         'Average distance the ball went after being hit before being touched by another player',
+                         field_rename='avg hit dist'),
     ]
     explanation_map = dict()
     for field in field_list:

--- a/backend/database/wrapper/stats/shared_stats_wrapper.py
+++ b/backend/database/wrapper/stats/shared_stats_wrapper.py
@@ -67,7 +67,7 @@ class SharedStatsWrapper:
                               DynamicFieldResult('collection boost efficiency'), is_percent=True),
             QueryFieldWrapper(stat_math.get_used_boost_efficiency(),
                               DynamicFieldResult('used boost efficiency'), is_percent=True),
-            QueryFieldWrapper(-stat_math.get_total_boost_efficiency(),
+            QueryFieldWrapper(stat_math.get_total_boost_efficiency(),
                               DynamicFieldResult('total boost efficiency'), is_percent=True),
             QueryFieldWrapper(stat_math.get_negative_turnover_per_non_dribble(),
                               DynamicFieldResult('turnover efficiency'), is_percent=True),

--- a/backend/database/wrapper/stats/stat_math.py
+++ b/backend/database/wrapper/stats/stat_math.py
@@ -55,7 +55,11 @@ def get_shot_percent():
 
 
 def get_negative_turnover_per_non_dribble():
-    return -100 * PlayerGame.turnovers / safe_divide(PlayerGame.total_hits - PlayerGame.total_dribble_conts)
+    return 100 - get_turnover_per_non_dribble()
+
+
+def get_turnover_per_non_dribble():
+    return 100 * PlayerGame.turnovers / safe_divide(PlayerGame.total_hits - PlayerGame.total_dribble_conts)
 
 
 def get_boost_ratio():

--- a/webapp/src/Models/ChartData.ts
+++ b/webapp/src/Models/ChartData.ts
@@ -13,9 +13,16 @@ export interface StatDataPoint extends ChartDataPoint {
     isOrange: boolean
 }
 
-export type BasicStatsSubcategory = "Hits" | "Ball" | "Positioning" | "Boosts" | "Playstyles" | "Possession" | "Efficiency"
+export type BasicStatsSubcategory =
+    "Hits"
+    | "Ball"
+    | "Positioning"
+    | "Boosts"
+    | "Playstyles"
+    | "Possession"
+    | "Efficiency"
 export const basicStatsSubcategoryValues = [
-    "Hits", "Ball", "Positioning", "Boosts",  "Playstyles", "Possession"
+    "Hits", "Ball", "Positioning", "Boosts", "Playstyles", "Possession", "Efficiency"
 ]  // Needed as these values cannot be gotten from the type at runtime (TypeScript is a lie)
 export interface BasicStat extends ChartDataResponse {
     chartDataPoints: StatDataPoint[]


### PR DESCRIPTION
So instead of just having basic stats be derived solely from the PlayerGame object (i.e. using `getattr` et al.), the basic stats portion uses the same math as the player playstyle / spider charts. So we can do complicated math and display the results quite easily in basic stats for a single replay.