### PR TITLE
Fix bug when trying to search with empty field

### DIFF
--- a/webapp/src/Components/Shared/Search.tsx
+++ b/webapp/src/Components/Shared/Search.tsx
@@ -82,6 +82,9 @@ class SearchComponent extends React.PureComponent<Props, State> {
 
     private readonly onSubmit: React.FormEventHandler = (e) => {
         e.preventDefault()
+        if (this.state.enteredText.length === 0) {
+            return
+        }
         resolvePlayerNameOrId(this.state.enteredText)
             .then((resolvedId) => this.setState({resolvedId}))
             .catch((appError: AppError) => this.props.showNotification({


### PR DESCRIPTION
While using calculated.gg, I noticed a small bug when clicking the search button with an empty text field. As it turns out, a request containing this empty string was sent to the server and resulted in a JSON parsing exception being displayed to the user.
I thus decided to take a few minutes to fix this.
You can see a screenshot of the issue below:
![image](https://user-images.githubusercontent.com/7671307/47250567-266c2200-d3f1-11e8-9dfa-31427568a6bb.png)