### PR TITLE
[#136] Dockerize dev environment, take 2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ fabric.properties
 config.cfg
 .DS_Store
 *.iml
+data/postgres/
 
 parsed/
 rlreplays/

--- a/Dockerfile-python
+++ b/Dockerfile-python
@@ -1,0 +1,20 @@
+FROM python:3.6-alpine
+
+WORKDIR /app
+
+ENV DOCKERIZE_VERSION v0.6.1
+
+ADD requirements.txt .
+
+RUN apk --no-cache --update-cache add \
+    build-base \
+    freetype-dev \
+    gcc \
+    libpng-dev \
+    musl-dev \
+    postgresql-dev
+RUN pip install --no-cache-dir -r requirements.txt
+
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz

--- a/README.md
+++ b/README.md
@@ -47,68 +47,20 @@ The structure of the server is split into different directories:
 
 ### Basic Dependencies
 
-- Install Python 3.6/pip
-- (Recommended) Create a virtual environment. todo(kcolton): finish + Pipfile
 - [Docker Community Edition (Stable)](https://docs.docker.com/install/)
   
-  Docker will run Postgres and Redis inside linux based "Containers" on most platforms. 
-  Download and install Docker for your platform:    
+  Docker will run Postgres, Redis, Flask, Celery, and Node inside linux based "Containers" on most platforms. 
+  Download and install Docker and Docker Compose for your platform:    
   - [Mac/Windows: Docker Desktop](https://www.docker.com/products/docker-desktop)
   - [Ubuntu/Debian-ish: Docker CLI](https://docs.docker.com/install/linux/docker-ce/debian/#install-docker-ce)
-- Start Postgres and Redis containers:
 
-    ```bash
-    # Start Postgres and Redis. Anytime ran will automatically download latest versions.
-    # Should be in project root directory (where docker-compose.yml is)
-    docker-compose up
-    
-    # See your containers running
-    docker ps
-    ```
-    
-    todo(kcolton): extended Docker docs
-- Install [NodeJS](https://nodejs.org/en/) - 8 LTS Recommended (10 likely works as well).
-
-
-### Python Requirements
-
-- (Recommended) Activate virtual environment. todo(kcolton): finish 
-- Install python requirements
-
-    ```bash
-    pip3 install -r requirements.txt
-    ```
-    
-### React Webapp requirements via `npm` (Node Package Manager)
-
+### Run Everything
 ```bash
-cd webapp
-# if not found, upgrade npm or use: npm install
-npm ci
+# Start containers. Should be in project root directory (where docker-compose.yml is)
+docker-compose up
+
+# See your containers running
+docker ps
 ```
 
-### Start Application
-
-todo(kcolton): alternative start methods
-
-- Flask (Web framework for Backend API)
-
-    ```bash
-    # inside activated virtual environment if cerated
-    python3 RLBotServer.py
-    ```
-    
-- Celery (Background workers required for parsing replays and other tasks)
-
-    ```bash
-    # inside activated virtual environment if created
-    celery -A backend.tasks.celery_tasks.celery worker --loglevel=INFO
-    ```
-    
-- React Web Frontend (Run on separate port, make calls to Backend API for data)
-
-    ```bash
-    cd webapp
-    npm run start
-    ```
-
+Now go to `localhost:3000` and the site should be running.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,19 +7,51 @@ services:
     restart: always
     environment:
       POSTGRES_PASSWORD: postgres
+    network_mode: service:flask
     volumes:
       - "./data/postgres:/var/lib/postgresql/data"
-    ports:
-      - 5432:5432
 
   redis:
     image: redis:4-alpine
     container_name: ccgg-redis4
     restart: always
+    network_mode: service:flask
     volumes:
       - "./.data/redis:/data"
+
+  flask:
+    build:
+      context: .
+      dockerfile: Dockerfile-python
+    image: distributed-replays-python
+    # The sleep is less than ideal but there seems to be a delay between
+    # when dockerize can connect to postgres and when our backend can
+    command: sh -c "dockerize -timeout 30s -wait tcp://localhost:5432 -wait tcp://localhost:6379 && sleep 3 && python ./RLBotServer.py"
+    volumes:
+      - ./:/app:rw
     ports:
+      # This container handles exporting the ports for every other container
+      # Those other containers link to this one
+      - 3000:3000
+      - 5432:5432
       - 6379:6379
+      - 8000:8000
+
+  celery:
+    image: distributed-replays-python
+    command: sh -c "dockerize -wait tcp://localhost:6379 celery -A backend.tasks.celery_tasks.celery worker --loglevel=INFO"
+    network_mode: service:flask
+    volumes:
+      - ./:/app:rw
+    depends_on:
+      - redis
+
+  webapp:
+    image: node:10-alpine
+    command: sh -c "cd /app && npm install && npm run start"
+    network_mode: service:flask
+    volumes:
+      - ./webapp/:/app:rw
 
 #  rabbitmq:
 #    image: rabbitmq:3-alpine


### PR DESCRIPTION
WORK IN PROGRESS. I figured out a much better approach to dockerization.

This adds a docker-only development environment. To use it:

* Install docker & docker-compose on your system
* Run `docker-compose up` (It'll take close to 20 min to build the docker images the first time)
* Go to `localhost:3000`
* Profit

Please clone this and try it out, let me know if you have any issues. Everything should work like normal.