### PR TITLE
Using Redux Actions

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -3876,11 +3876,13 @@
                 },
                 "balanced-match": {
                     "version": "1.0.0",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -3893,15 +3895,18 @@
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -4004,7 +4009,8 @@
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -4014,6 +4020,7 @@
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -4026,17 +4033,20 @@
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
                     "version": "0.0.8",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.2.4",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.1",
                         "yallist": "^3.0.0"
@@ -4053,6 +4063,7 @@
                 "mkdirp": {
                     "version": "0.5.1",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -4125,7 +4136,8 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -4135,6 +4147,7 @@
                 "once": {
                     "version": "1.4.0",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -4240,6 +4253,7 @@
                 "string-width": {
                     "version": "1.0.2",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -280,6 +280,12 @@
                 "@types/react": "*"
             }
         },
+        "@types/redux-actions": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/@types/redux-actions/-/redux-actions-2.3.1.tgz",
+            "integrity": "sha512-MMI9LtIn1lotGOJ45PPCXB3ksn0jxditnqSOZjs7gnFCB1o5UagFtnSNkaJ4dWioNKdTPh08hddj/Hh1aPaoRA==",
+            "dev": true
+        },
         "abab": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
@@ -3876,13 +3882,11 @@
                 },
                 "balanced-match": {
                     "version": "1.0.0",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -3895,18 +3899,15 @@
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -4009,8 +4010,7 @@
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -4020,7 +4020,6 @@
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -4033,20 +4032,17 @@
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
                     "version": "0.0.8",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "minipass": {
                     "version": "2.2.4",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.1",
                         "yallist": "^3.0.0"
@@ -4063,7 +4059,6 @@
                 "mkdirp": {
                     "version": "0.5.1",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -4136,8 +4131,7 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -4147,7 +4141,6 @@
                 "once": {
                     "version": "1.4.0",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -4253,7 +4246,6 @@
                 "string-width": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -6186,6 +6178,11 @@
             "requires": {
                 "css-vendor": "^0.3.8"
             }
+        },
+        "just-curry-it": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/just-curry-it/-/just-curry-it-3.1.0.tgz",
+            "integrity": "sha512-mjzgSOFzlrurlURaHVjnQodyPNvrHrf1TbQP2XU9NSqBtHQPuHZ+Eb6TAJP7ASeJN9h9K0KXoRTs8u6ouHBKvg=="
         },
         "keycode": {
             "version": "2.2.0",
@@ -9123,6 +9120,11 @@
                 "balanced-match": "^0.4.2"
             }
         },
+        "reduce-reducers": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/reduce-reducers/-/reduce-reducers-0.4.3.tgz",
+            "integrity": "sha512-+CNMnI8QhgVMtAt54uQs3kUxC3Sybpa7Y63HR14uGLgI9/QR5ggHvpxwhGGe3wmx5V91YwqQIblN9k5lspAmGw=="
+        },
         "redux": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.0.tgz",
@@ -9137,6 +9139,18 @@
                     "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
                     "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
                 }
+            }
+        },
+        "redux-actions": {
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/redux-actions/-/redux-actions-2.6.4.tgz",
+            "integrity": "sha512-Gho+gnsvyR5h0pApoMdHLYssVEu4I0DNqyC91u43Xy/BvLrEddEMtukLF8oL3WXUy7DjxqKOKZHKmpKyN6hxlQ==",
+            "requires": {
+                "invariant": "^2.2.4",
+                "just-curry-it": "^3.1.0",
+                "loose-envify": "^1.4.0",
+                "reduce-reducers": "^0.4.3",
+                "to-camel-case": "^1.0.0"
             }
         },
         "redux-devtools-extension": {
@@ -10646,10 +10660,23 @@
             "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
             "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
         },
+        "to-camel-case": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/to-camel-case/-/to-camel-case-1.0.0.tgz",
+            "integrity": "sha1-GlYFSy+daWKYzmamCJcyK29CPkY=",
+            "requires": {
+                "to-space-case": "^1.0.0"
+            }
+        },
         "to-fast-properties": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
             "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+        },
+        "to-no-case": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
+            "integrity": "sha1-xyKQcWTvaxeBMsjmmTAhLRtKoWo="
         },
         "to-object-path": {
             "version": "0.3.0",
@@ -10687,6 +10714,14 @@
                         "kind-of": "^3.0.2"
                     }
                 }
+            }
+        },
+        "to-space-case": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz",
+            "integrity": "sha1-sFLar7Gysp3HcM6gFj5ewOvJ/Bc=",
+            "requires": {
+                "to-no-case": "^1.0.0"
             }
         },
         "toposort": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -22,6 +22,7 @@
         "react-router-dom": "^4.3.1",
         "react-scripts-ts": "2.17.0",
         "redux": "^4.0.0",
+        "redux-actions": "^2.6.4",
         "redux-devtools-extension": "^2.13.5",
         "three": "^0.96.0"
     },
@@ -44,6 +45,7 @@
         "@types/react-dom": "^16.0.7",
         "@types/react-redux": "^6.0.9",
         "@types/react-router-dom": "^4.3.0",
+        "@types/redux-actions": "^2.3.1",
         "source-map-explorer": "^1.6.0",
         "tslint": "^5.11.0",
         "typescript": "^3.0.3"

--- a/webapp/src/Components/Pages/HomePage.tsx
+++ b/webapp/src/Components/Pages/HomePage.tsx
@@ -9,6 +9,7 @@ import * as React from "react"
 import { connect } from "react-redux"
 import { Link } from "react-router-dom"
 import { Dispatch } from "redux"
+import { LoggedInUserActions, StoreState } from "src/Redux"
 import {
     ABOUT_LINK,
     DISCORD_LINK,
@@ -21,8 +22,6 @@ import {
     TWITTER_LINK,
     UPLOAD_LINK
 } from "../../Globals"
-import { StoreState } from "../../Redux"
-import { setLoggedInUserAction } from "../../Redux/loggedInUser/actions"
 import { getLoggedInUser, getReplayCount } from "../../Requests/Global"
 import { LinkButton } from "../Shared/LinkButton"
 import { Logo } from "../Shared/Logo/Logo"
@@ -209,7 +208,7 @@ export const mapStateToProps = (state: StoreState) => ({
 })
 
 export const mapDispatchToProps = (dispatch: Dispatch) => ({
-    setLoggedInUser: (loggedInUser: LoggedInUser) => dispatch(setLoggedInUserAction(loggedInUser))
+    setLoggedInUser: (loggedInUser: LoggedInUser) => dispatch(LoggedInUserActions.setLoggedInUserAction(loggedInUser))
 })
 
 export const HomePage = withWidth()(withStyles(styles)(

--- a/webapp/src/Components/Shared/NavBar/AccountMenu.tsx
+++ b/webapp/src/Components/Shared/NavBar/AccountMenu.tsx
@@ -14,8 +14,8 @@ import {
 } from "@material-ui/core"
 import * as React from "react"
 import { Link } from "react-router-dom"
+import { LoggedInUserState } from "src/Redux/loggedInUser/reducer"
 import { LOCAL_LINK, LOGOUT_LINK, PLAYER_PAGE_LINK, STEAM_LOGIN_LINK } from "../../../Globals"
-import { LoggedInUserState } from "../../../Redux/loggedInUser/actions"
 import { LinkButton } from "../LinkButton"
 
 interface OwnProps {

--- a/webapp/src/Components/Shared/NavBar/NavBar.tsx
+++ b/webapp/src/Components/Shared/NavBar/NavBar.tsx
@@ -17,9 +17,8 @@ import * as React from "react"
 import { connect } from "react-redux"
 import { Link } from "react-router-dom"
 import { Dispatch } from "redux"
+import { LoggedInUserActions, StoreState } from "src/Redux"
 import { GLOBAL_STATS_LINK } from "../../../Globals"
-import { StoreState } from "../../../Redux"
-import { setLoggedInUserAction } from "../../../Redux/loggedInUser/actions"
 import { getLoggedInUser } from "../../../Requests/Global"
 import { Logo } from "../Logo/Logo"
 import { Search } from "../Search"
@@ -110,7 +109,7 @@ export const mapStateToProps = (state: StoreState) => ({
 })
 
 export const mapDispatchToProps = (dispatch: Dispatch) => ({
-    setLoggedInUser: (loggedInUser: LoggedInUser) => dispatch(setLoggedInUserAction(loggedInUser))
+    setLoggedInUser: (loggedInUser: LoggedInUser) => dispatch(LoggedInUserActions.setLoggedInUserAction(loggedInUser))
 })
 
 export const NavBar = withWidth()(withStyles(styles)(

--- a/webapp/src/Components/Shared/Notification/NotificationTestButton.tsx
+++ b/webapp/src/Components/Shared/Notification/NotificationTestButton.tsx
@@ -2,7 +2,7 @@ import { Button } from "@material-ui/core"
 import * as React from "react"
 import { connect } from "react-redux"
 import { Dispatch } from "redux"
-import { showNotifictionAction } from "../../../Redux/notifications/actions"
+import { NotificationActions } from "src/Redux"
 import { NotificationProps } from "./NotificationSnackbar"
 
 type Props = ReturnType<typeof mapDispatchToProps>
@@ -40,7 +40,8 @@ class NotificationTestButtonComponent extends React.PureComponent<Props, State> 
 }
 
 export const mapDispatchToProps = (dispatch: Dispatch) => ({
-    showNotification: (notificationProps: NotificationProps) => dispatch(showNotifictionAction(notificationProps))
+    showNotification: (notificationProps: NotificationProps) =>
+        dispatch(NotificationActions.showNotifictionAction(notificationProps))
 })
 
 export const NotificationTestButton = connect(null, mapDispatchToProps)(NotificationTestButtonComponent)

--- a/webapp/src/Components/Shared/Notification/NotificationUtils.ts
+++ b/webapp/src/Components/Shared/Notification/NotificationUtils.ts
@@ -1,10 +1,11 @@
 import { connect } from "react-redux"
 import { Dispatch } from "redux"
-import { showNotifictionAction } from "../../../Redux/notifications/actions"
+import { NotificationActions } from "src/Redux/notifications/actions"
 import { NotificationProps } from "./NotificationSnackbar"
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-    showNotification: (notificationProps: NotificationProps) => dispatch(showNotifictionAction(notificationProps))
+    showNotification: (notificationProps: NotificationProps) =>
+    dispatch(NotificationActions.showNotifictionAction(notificationProps))
 })
 
 export type WithNotifications = ReturnType<typeof mapDispatchToProps>

--- a/webapp/src/Components/Shared/Notification/NotificationUtils.ts
+++ b/webapp/src/Components/Shared/Notification/NotificationUtils.ts
@@ -5,7 +5,7 @@ import { NotificationProps } from "./NotificationSnackbar"
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
     showNotification: (notificationProps: NotificationProps) =>
-    dispatch(NotificationActions.showNotifictionAction(notificationProps))
+        dispatch(NotificationActions.showNotifictionAction(notificationProps))
 })
 
 export type WithNotifications = ReturnType<typeof mapDispatchToProps>

--- a/webapp/src/Components/Shared/Notification/Notifications.tsx
+++ b/webapp/src/Components/Shared/Notification/Notifications.tsx
@@ -1,8 +1,7 @@
 import * as React from "react"
 import { connect } from "react-redux"
 import { Dispatch } from "redux"
-import { StoreState } from "../../../Redux"
-import { dismissNotificationAction } from "../../../Redux/notifications/actions"
+import { NotificationActions, StoreState } from "../../../Redux"
 import { NotificationProps, NotificationSnackbar } from "./NotificationSnackbar"
 
 type Props = ReturnType<typeof mapStateToProps>
@@ -53,7 +52,7 @@ export const mapStateToProps = (state: StoreState) => ({
 })
 
 export const mapDispatchToProps = (dispatch: Dispatch) => ({
-    dismissNotification: () => dispatch(dismissNotificationAction())
+    dismissNotification: () => dispatch(NotificationActions.dismissNotificationAction())
 })
 
 export const Notifications = connect(mapStateToProps, mapDispatchToProps)(NotificationsComponent)

--- a/webapp/src/Components/Shared/Notification/Notifications.tsx
+++ b/webapp/src/Components/Shared/Notification/Notifications.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { connect } from "react-redux"
 import { Dispatch } from "redux"
-import { NotificationActions, StoreState } from "../../../Redux"
+import { NotificationActions, StoreState } from "src/Redux"
 import { NotificationProps, NotificationSnackbar } from "./NotificationSnackbar"
 
 type Props = ReturnType<typeof mapStateToProps>

--- a/webapp/src/Redux/index.ts
+++ b/webapp/src/Redux/index.ts
@@ -1,8 +1,7 @@
 import { combineReducers, createStore, Reducer } from "redux"
 import { devToolsEnhancer } from "redux-devtools-extension"
 import { loggedInUserReducer, LoggedInUserState } from "./loggedInUser/reducer"
-import { NotificationsState } from "./notifications/actions"
-import { notificationsReducer } from "./notifications/reducer"
+import { notificationsReducer, NotificationsState } from "./notifications/reducer"
 
 export interface StoreState {
     loggedInUser: LoggedInUserState
@@ -19,3 +18,4 @@ export const store = createStore(
 )
 
 export * from "./loggedInUser/actions"
+export * from "./notifications/actions"

--- a/webapp/src/Redux/index.ts
+++ b/webapp/src/Redux/index.ts
@@ -1,11 +1,11 @@
 import { combineReducers, createStore, Reducer } from "redux"
 import { devToolsEnhancer } from "redux-devtools-extension"
-import { loggedInUserReducer } from "./loggedInUser/reducer"
+import { loggedInUserReducer, LoggedInUserState } from "./loggedInUser/reducer"
 import { NotificationsState } from "./notifications/actions"
 import { notificationsReducer } from "./notifications/reducer"
 
 export interface StoreState {
-    loggedInUser: LoggedInUser | null
+    loggedInUser: LoggedInUserState
     notifications: NotificationsState
 }
 
@@ -17,3 +17,5 @@ const rootReducer: Reducer<StoreState> = combineReducers<StoreState>({
 export const store = createStore(
     rootReducer, devToolsEnhancer({})
 )
+
+export * from "./loggedInUser/actions"

--- a/webapp/src/Redux/loggedInUser/actions.ts
+++ b/webapp/src/Redux/loggedInUser/actions.ts
@@ -1,14 +1,12 @@
-import { Action } from "redux"
+import { Omit } from "lodash"
+import { createAction } from "redux-actions"
 
-interface SetLoggedInUserAction extends Action<"SET_LOGGED_IN_USER"> {
-    loggedInUser: LoggedInUser
+export namespace LoggedInUserActions {
+    export enum Type {
+        SET_LOGGED_IN_USER = "SET_LOGGED_IN_USER"
+    }
+
+    export const setLoggedInUserAction = createAction<LoggedInUser>(Type.SET_LOGGED_IN_USER)
 }
 
-export const setLoggedInUserAction = (loggedInUser: LoggedInUser): SetLoggedInUserAction => ({
-    loggedInUser,
-    type: "SET_LOGGED_IN_USER"
-})
-
-export type LoggedInUserActionTypes = SetLoggedInUserAction
-
-export type LoggedInUserState = LoggedInUser | null
+export type LoggedInUserActions = Omit<typeof LoggedInUserActions, "Type">

--- a/webapp/src/Redux/loggedInUser/reducer.ts
+++ b/webapp/src/Redux/loggedInUser/reducer.ts
@@ -1,12 +1,12 @@
-import { Reducer } from "redux"
-import { LoggedInUserActionTypes, LoggedInUserState } from "./actions"
+import { Action, handleActions } from "redux-actions"
+import { LoggedInUserActions } from "./actions"
 
-export const loggedInUserReducer: Reducer<LoggedInUserState, LoggedInUserActionTypes> = (
-    state = null, action) => {
-    switch (action.type) {
-        case "SET_LOGGED_IN_USER":
-            return {...action.loggedInUser}
-        default:
-            return state
+export type LoggedInUserState = LoggedInUser | null
+
+const initialState: LoggedInUserState = null
+
+export const loggedInUserReducer = handleActions({
+    [LoggedInUserActions.Type.SET_LOGGED_IN_USER]: (state, action: Action<LoggedInUser>): LoggedInUserState => {
+        return action.payload || null
     }
-}
+}, initialState)

--- a/webapp/src/Redux/notifications/actions.ts
+++ b/webapp/src/Redux/notifications/actions.ts
@@ -1,22 +1,15 @@
-import { Action } from "redux"
+import { Omit } from "lodash"
+import { createAction } from "redux-actions"
 import { NotificationProps } from "../../Components/Shared/Notification/NotificationSnackbar"
 
-interface ShowNotifictionAction extends Action<"SHOW_NOTIFICATION"> {
-    notification: NotificationProps
+export namespace NotificationActions {
+    export enum Type {
+        SHOW_NOTIFICATION = "SHOW_NOTIFICATION",
+        DISMISS_NOTIFICATION = "DISMISS_NOTIFICATION"
+    }
+
+    export const showNotifictionAction = createAction<NotificationProps>(Type.SHOW_NOTIFICATION)
+    export const dismissNotificationAction = createAction(Type.DISMISS_NOTIFICATION)
 }
 
-export const showNotifictionAction = (notification: NotificationProps): ShowNotifictionAction => ({
-    notification,
-    type: "SHOW_NOTIFICATION"
-})
-
-type DismissNotificationAction = Action<"DISMISS_NOTIFICATION">
-
-export const dismissNotificationAction = (): DismissNotificationAction => ({
-    type: "DISMISS_NOTIFICATION"
-})
-
-export type NotificationsActionTypes = ShowNotifictionAction
-    | DismissNotificationAction
-
-export type NotificationsState = NotificationProps[]
+export type NotificationActions = Omit<typeof NotificationActions, "Type">

--- a/webapp/src/Redux/notifications/reducer.ts
+++ b/webapp/src/Redux/notifications/reducer.ts
@@ -1,14 +1,22 @@
-import { Reducer } from "redux"
-import { NotificationsActionTypes, NotificationsState } from "./actions"
+import { Action, handleActions } from "redux-actions"
+import { NotificationProps } from "src/Components/Shared/Notification/NotificationSnackbar"
+import { NotificationActions } from "./actions"
 
-export const notificationsReducer: Reducer<NotificationsState, NotificationsActionTypes> = (
-    state = [], action) => {
-    switch (action.type) {
-        case "SHOW_NOTIFICATION":
-            return [...state, action.notification]
-        case "DISMISS_NOTIFICATION":
-            return state.slice(1)
-        default:
-            return state
+export type NotificationsState = NotificationProps[]
+
+const initialState: NotificationsState = []
+
+export const notificationsReducer = handleActions({
+    [NotificationActions.Type.SHOW_NOTIFICATION]: (state: NotificationsState, action: Action<NotificationProps>):
+    NotificationsState => {
+        if (action.payload) {
+            return [...state, action.payload]
+        }
+        return state
+
+    },
+    [NotificationActions.Type.DISMISS_NOTIFICATION]: (state: NotificationsState, _):
+    NotificationsState => {
+        return state.slice(1)
     }
-}
+}, initialState)

--- a/webapp/tslint.json
+++ b/webapp/tslint.json
@@ -38,6 +38,7 @@
         "no-empty": true,
         "no-empty-interface": false,
         "no-invalid-this": true,
+        "no-namespace": false,
         "no-require-imports": true,
         "no-this-assignment": true,
         "no-trailing-whitespace": true,


### PR DESCRIPTION
This lays the foundation for the Redux work I want to prepare before working on caching API requests. Converts the existing action/reducer structure to use [redux-actions](https://github.com/redux-utilities/redux-actions). We want to consolidate hardcoded strings into an easily accessible list, and namespace actions because we tend to use them around each other.