### PR TITLE
Fix rendering of comparison page

### DIFF
--- a/webapp/src/Components/Player/Compare/PlayStyle/PlayerComparePlayStyleCharts.tsx
+++ b/webapp/src/Components/Player/Compare/PlayStyle/PlayerComparePlayStyleCharts.tsx
@@ -91,14 +91,14 @@ export class PlayerComparePlayStyleCharts extends React.PureComponent<Props, Sta
 
         if (playerPlayStyles.length === 0) {
             return (
-	          <>
+	            <>
                 <Grid item xs={12} style={{textAlign: "center"}}>
                     {rankSelect}
                 </Grid>
                 <Grid item xs={12} style={{textAlign: "center"}}>
                     {dropDown}
                 </Grid>
-	         </>
+	           </>
 	        )
         }
 

--- a/webapp/src/Components/Player/Compare/PlayStyle/PlayerComparePlayStyleCharts.tsx
+++ b/webapp/src/Components/Player/Compare/PlayStyle/PlayerComparePlayStyleCharts.tsx
@@ -62,15 +62,7 @@ export class PlayerComparePlayStyleCharts extends React.PureComponent<Props, Sta
     public render() {
         const {players} = this.props
         const {playerPlayStyles, playerPlayStylesRaw} = this.state
-        if (playerPlayStyles.length === 0) {
-            return null
-        }
 
-        const compareChartDatas = playerPlayStyles[0].chartDatas
-            .map((_, i) => playerPlayStyles
-                .map((playStyleResponse) => playStyleResponse.chartDatas[i])
-            )
-        const chartTitles = playerPlayStyles[0].chartDatas.map((chartData) => chartData.title)
         const checkbox = (
             <FormControlLabel
                 control={<Switch onChange={this.handleHeatmapChange}/>}
@@ -88,14 +80,39 @@ export class PlayerComparePlayStyleCharts extends React.PureComponent<Props, Sta
                 currentPlaylistsOnly
                 multiple={false}/>
         )
+
+        const rankSelect = (
+            <RankSelect selectedRank={this.state.rank || -1}
+                        handleChange={this.handleRankChange}
+                        inputLabel="Rank to compare"
+                        helperText="Select the rank to plot as average"
+                        noneLabel="Default"/>
+        )
+
+        if (playerPlayStyles.length === 0) {
+            return (
+	          <>
+                <Grid item xs={12} style={{textAlign: "center"}}>
+                    {rankSelect}
+                </Grid>
+                <Grid item xs={12} style={{textAlign: "center"}}>
+                    {dropDown}
+                </Grid>
+	         </>
+	        )
+        }
+
+        const compareChartDatas = playerPlayStyles[0].chartDatas
+            .map((_, i) => playerPlayStyles
+                .map((playStyleResponse) => playStyleResponse.chartDatas[i])
+            )
+
+        const chartTitles = playerPlayStyles[0].chartDatas.map((chartData) => chartData.title)
+
         return (
             <>
                 <Grid item xs={12} style={{textAlign: "center"}}>
-                    <RankSelect selectedRank={this.state.rank || -1}
-                                handleChange={this.handleRankChange}
-                                inputLabel="Rank to compare"
-                                helperText="Select the rank to plot as average"
-                                noneLabel="Default"/>
+                    {rankSelect}
                 </Grid>
                 <Grid item xs={12} style={{textAlign: "center"}}>
                     {dropDown}

--- a/webapp/src/Components/Player/Compare/PlayStyle/PlayerComparePlayStyleCharts.tsx
+++ b/webapp/src/Components/Player/Compare/PlayStyle/PlayerComparePlayStyleCharts.tsx
@@ -91,15 +91,15 @@ export class PlayerComparePlayStyleCharts extends React.PureComponent<Props, Sta
 
         if (playerPlayStyles.length === 0) {
             return (
-	            <>
+              <>
                 <Grid item xs={12} style={{textAlign: "center"}}>
                     {rankSelect}
                 </Grid>
                 <Grid item xs={12} style={{textAlign: "center"}}>
                     {dropDown}
                 </Grid>
-	           </>
-	        )
+              </>
+            )
         }
 
         const compareChartDatas = playerPlayStyles[0].chartDatas


### PR DESCRIPTION
A check already existed for a playlist returning no data. However, it returned null rather than returning the dropdowns for rank and playlist selection. 

I followed the pattern set with fragments of JSX. Ideally the conditional for rendering isn't split from the main return of JSX. But that would require some more thorough refactoring.