### PR TITLE
Add groups to players for easier object attachment

### DIFF
--- a/webapp/src/Components/Replay/ReplayViewer/ThreeScene.tsx
+++ b/webapp/src/Components/Replay/ReplayViewer/ThreeScene.tsx
@@ -355,7 +355,7 @@ export class ThreeScene extends React.PureComponent<Props> {
         }
         const generateClip = (posRotData: any[], objectName: string) => {
             const positions: number[] = []
-            const angles: number[] = []
+            const rotations: number[] = []
             /**
              * We are calculating vector and quaternion times independently because there are often
              * cases where the data of a frame might coincide with the data of the next frame. The
@@ -376,25 +376,25 @@ export class ThreeScene extends React.PureComponent<Props> {
              * kickoff occurs.
              */
             let totalDuration = 0
-            const vectorTimes: number[] = []
-            const quatTimes: number[] = []
+            const positionTimes: number[] = []
+            const rotationTimes: number[] = []
             let prevVector = new Vector3(0, 0, 0)
-            let prevQuat = new Quaternion(0, 0, 0)
+            let prevQuat = new Quaternion(0, 0, 0, 0)
             posRotData.forEach((data, index) => {
                 // Apply position frame
                 const newVector = dataToVector(data)
-                const lastVectorFrame = vectorTimes.length ? vectorTimes[vectorTimes.length - 1] : 0
+                const lastVectorFrame = positionTimes.length ? positionTimes[positionTimes.length - 1] : 0
                 if (!newVector.equals(prevVector) || totalDuration - lastVectorFrame > 2.9) {
                     newVector.toArray(positions, positions.length)
-                    vectorTimes.push(totalDuration)
+                    positionTimes.push(totalDuration)
                     prevVector = newVector
                 }
                 // Apply rotation frame
                 const newQuat = dataToQuaternion(data)
-                const lastQuatFrame = quatTimes.length ? quatTimes[quatTimes.length - 1] : 0
+                const lastQuatFrame = rotationTimes.length ? rotationTimes[rotationTimes.length - 1] : 0
                 if (!newQuat.equals(prevQuat) || totalDuration - lastQuatFrame > 2.9) {
-                    newQuat.toArray(angles, angles.length)
-                    quatTimes.push(totalDuration)
+                    newQuat.toArray(rotations, rotations.length)
+                    rotationTimes.push(totalDuration)
                     prevQuat = newQuat
                 }
                 // Add the delta
@@ -405,13 +405,13 @@ export class ThreeScene extends React.PureComponent<Props> {
             // the object we wish to modify must have this associated name.
             const positionKeyframes = new VectorKeyframeTrack(
                 `${objectName}.position`,
-                vectorTimes,
+                positionTimes,
                 positions
             )
             const rotationKeyframes = new QuaternionKeyframeTrack(
                 `${objectName}.quaternion`,
-                quatTimes,
-                angles
+                rotationTimes,
+                rotations
             )
 
             return new AnimationClip(`${objectName}Action`, totalDuration, [

--- a/webapp/src/Components/Replay/ReplayViewer/ThreeScene.tsx
+++ b/webapp/src/Components/Replay/ReplayViewer/ThreeScene.tsx
@@ -426,9 +426,9 @@ export class ThreeScene extends React.PureComponent<Props> {
             })
 
             return {
+                duration: totalDuration,
                 positionTimes,
                 positionValues: positions,
-                duration: totalDuration,
                 rotationTimes,
                 rotationValues: rotations
             }
@@ -437,57 +437,47 @@ export class ThreeScene extends React.PureComponent<Props> {
         for (let player = 0; player < this.props.replayData.players.length; player++) {
             const playerData = this.props.replayData.players[player]
             const playerName = `${this.props.replayData.names[player]}`
-            const {
-                duration,
-                positionTimes,
-                positionValues,
-                rotationTimes,
-                rotationValues
-            } = generateKeyframeData(playerData)
+            const playerKeyframeData = generateKeyframeData(playerData)
 
             // Note that Three.JS requires this .position/.quaternion naming convention, and that
             // the object we wish to modify must have this associated name.
             const playerPosKeyframes = new VectorKeyframeTrack(
                 `${playerName}.position`,
-                positionTimes,
-                positionValues
+                playerKeyframeData.positionTimes,
+                playerKeyframeData.positionValues
             )
             const playerRotKeyframes = new QuaternionKeyframeTrack(
                 `${playerName}-car.quaternion`,
-                rotationTimes,
-                rotationValues
+                playerKeyframeData.rotationTimes,
+                playerKeyframeData.rotationValues
             )
 
-            const playerClip = new AnimationClip(`${playerName}Action`, duration, [
-                playerPosKeyframes,
-                playerRotKeyframes
-            ])
+            const playerClip = new AnimationClip(
+                `${playerName}Action`,
+                playerKeyframeData.duration,
+                [playerPosKeyframes, playerRotKeyframes]
+            )
             this.animator.playerClips.push(playerClip)
         }
         // Then, generate the ball clip
         const ballData = this.props.replayData.ball
-        const {
-            duration,
-            positionTimes,
-            positionValues,
-            rotationTimes,
-            rotationValues
-        } = generateKeyframeData(ballData)
+        const ballKeyframeData = generateKeyframeData(ballData)
 
         const ballPosKeyframes = new VectorKeyframeTrack(
             `${BALL_NAME}.position`,
-            positionTimes,
-            positionValues
+            ballKeyframeData.positionTimes,
+            ballKeyframeData.positionValues
         )
         const ballRotKeyframes = new QuaternionKeyframeTrack(
             `${BALL_NAME}.quaternion`,
-            rotationTimes,
-            rotationValues
+            ballKeyframeData.rotationTimes,
+            ballKeyframeData.rotationValues
         )
-        this.animator.ballClip = new AnimationClip(`${BALL_NAME}Action`, duration, [
-            ballPosKeyframes,
-            ballRotKeyframes
-        ])
+        this.animator.ballClip = new AnimationClip(
+            `${BALL_NAME}Action`,
+            ballKeyframeData.duration,
+            [ballPosKeyframes, ballRotKeyframes]
+        )
     }
 
     private readonly updateCamera = () => {

--- a/webapp/src/Components/Replay/ReplayViewer/ThreeScene.tsx
+++ b/webapp/src/Components/Replay/ReplayViewer/ThreeScene.tsx
@@ -15,6 +15,7 @@ import {
     HemisphereLight,
     LoadingManager,
     Mesh,
+    MeshNormalMaterial,
     MeshPhongMaterial,
     Object3D,
     PerspectiveCamera,
@@ -315,16 +316,27 @@ export class ThreeScene extends React.PureComponent<Props> {
                 const carGeometry = new BoxBufferGeometry(84.2, 117, 36.16)
                 const carColor = this.props.replayData.colors[i] ? "#ff9800" : "#2196f3"
                 const carMaterial = new MeshPhongMaterial({ color: i ? carColor : "#333333" })
-                const player = new Group()
+                const playerMesh = new Group()
+                playerMesh.name = `${players[i]}-car`
                 if (i > 2) {
-                    player.add(new Mesh(carGeometry, carMaterial))
+                    playerMesh.add(new Mesh(carGeometry, carMaterial))
                 } else {
-                    player.add(octane.clone())
+                    playerMesh.add(octane.clone())
                 }
-                player.add(new AxesHelper(150))
-                player.name = players[i]
+                playerMesh.add(new AxesHelper(150))
 
-                if (this.props.replayData.names[i] === "Sciguymjm") {
+                const player = new Group()
+                player.name = players[i]
+                player.add(playerMesh)
+
+                const indicator = new Mesh(
+                    new BoxBufferGeometry(30, 30, 100),
+                    new MeshNormalMaterial()
+                )
+                indicator.position.y = 200
+                player.add(indicator)
+
+                if (i === 0) {
                     this.addToWindow(player, "player")
                 }
 
@@ -441,7 +453,7 @@ export class ThreeScene extends React.PureComponent<Props> {
                 positionValues
             )
             const playerRotKeyframes = new QuaternionKeyframeTrack(
-                `${playerName}.quaternion`,
+                `${playerName}-car.quaternion`,
                 rotationTimes,
                 rotationValues
             )

--- a/webapp/src/Components/Replay/ReplayViewer/ThreeScene.tsx
+++ b/webapp/src/Components/Replay/ReplayViewer/ThreeScene.tsx
@@ -281,7 +281,7 @@ export class ThreeScene extends React.PureComponent<Props> {
         const ballMaterial = new MeshPhongMaterial()
         const ball = new Mesh(ballGeometry, ballMaterial)
         ball.name = BALL_NAME
-        ball.add(new AxesHelper(150))
+        ball.add(new AxesHelper(200))
         this.animator.ballMixer = new AnimationMixer(ball)
 
         field.ball = ball
@@ -307,10 +307,14 @@ export class ThreeScene extends React.PureComponent<Props> {
                 const carGeometry = new BoxBufferGeometry(84.2, 117, 36.16)
                 const carColor = this.props.replayData.colors[i] ? "#ff9800" : "#2196f3"
                 const carMaterial = new MeshPhongMaterial({ color: i ? carColor : "#333333" })
-                const player = i > 2 ? new Mesh(carGeometry, carMaterial) : octane.clone()
-                // const player = octane.clone()
+                const player = new Group()
+                if (i > 2) {
+                    player.add(new Mesh(carGeometry, carMaterial))
+                } else {
+                    player.add(octane.clone())
+                }
+                player.add(new AxesHelper(150))
                 player.name = players[i]
-                player.add(new AxesHelper(10))
 
                 if (this.props.replayData.names[i] === "Sciguymjm") {
                     this.addToWindow(player, "player")


### PR DESCRIPTION
This also splits the animation of the position and rotation of a player onto two separate objects - the containing player group will have only its position modified while the car inside the group will have only its rotation modified. This should allow us to attach name tags, cameras, etc. without worrying about them being rotated along with the car.