### PR TITLE
Set submodule to track master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "webapp/public/assets/shared"]
 	path = webapp/public/assets/shared
 	url = https://github.com/SaltieRL/SharedAssets.git
+	branch = master

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -38,7 +38,7 @@
         "build": "react-scripts-ts build",
         "test": "react-scripts-ts test --env=jsdom",
         "eject": "react-scripts-ts eject",
-        "submodule": "git submodule update --init",
+        "submodule": "git submodule update --remote",
         "tslint-prettier-check": "tslint-config-prettier-check ./tslint.json"
     },
     "devDependencies": {


### PR DESCRIPTION
I meant to do this in the previous PR but now the submodule will track the master branch of the `SharedAssets` repo. Also I fixed the submodule script @Abbondanzo - `git submodule update --init` should only be run once if you do not already have the submodule in the `webapp/public/assets/shared` folder. From then on, updating the submodule uses the `git submodule update --remote` command.