### PR TITLE
Replay viewer optimizations

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -3925,13 +3925,11 @@
                 },
                 "balanced-match": {
                     "version": "1.0.0",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -3944,18 +3942,15 @@
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -4058,8 +4053,7 @@
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -4069,7 +4063,6 @@
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -4082,20 +4075,17 @@
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
                     "version": "0.0.8",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "minipass": {
                     "version": "2.2.4",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.1",
                         "yallist": "^3.0.0"
@@ -4112,7 +4102,6 @@
                 "mkdirp": {
                     "version": "0.5.1",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -4185,8 +4174,7 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -4196,7 +4184,6 @@
                 "once": {
                     "version": "1.4.0",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -4302,7 +4289,6 @@
                 "string-width": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",

--- a/webapp/src/Components/Replay/ReplayViewer/ThreeScene.tsx
+++ b/webapp/src/Components/Replay/ReplayViewer/ThreeScene.tsx
@@ -84,6 +84,10 @@ export class ThreeScene extends React.PureComponent<Props> {
         }
     }
 
+    public componentWillUpdate() {
+        console.log("Updating")
+    }
+
     public componentWillUnmount() {
         this.stop()
         if (this.stats) {

--- a/webapp/src/Components/Replay/ReplayViewer/ThreeScene.tsx
+++ b/webapp/src/Components/Replay/ReplayViewer/ThreeScene.tsx
@@ -88,6 +88,10 @@ export class ThreeScene extends React.PureComponent<Props> {
         console.log("Updating")
     }
 
+    public componentDidUpdate() {
+        this.addToWindow(this.props.clock, "clock")
+    }
+
     public componentWillUnmount() {
         this.stop()
         if (this.stats) {

--- a/webapp/src/Components/Replay/ReplayViewer/ThreeScene.tsx
+++ b/webapp/src/Components/Replay/ReplayViewer/ThreeScene.tsx
@@ -84,10 +84,6 @@ export class ThreeScene extends React.PureComponent<Props> {
         }
     }
 
-    public componentWillUpdate() {
-        console.log("Updating")
-    }
-
     public componentDidUpdate() {
         this.addToWindow(this.props.clock, "clock")
     }

--- a/webapp/src/Models/Replay/Clock.ts
+++ b/webapp/src/Models/Replay/Clock.ts
@@ -6,14 +6,16 @@
  * THREE.js animation system and communicate changes back to the parent container of animations so
  * that we can display data which is recorded at a frame and not at a time.
  *
- * When constructing this object, you should provide an array of elapsed durations, where each
- * index in the array represents the time since the beginning of the animation. The first index, 0,
- * should be set to 0 (the elapsed time since the start), followed by these times. For example:
+ * When constructing this object, you should provide an array of elapsed durations*1000, where each
+ * index in the array represents the time in milliseconds since the beginning of the animation. The
+ * first index, 0, should be set to 0 (the elapsed time since the start), followed by these times.
+ *
+ * For example:
  * 0: 0
- * 1: 0.0483877919614315
- * 2: 0.08385848999023438
- * 3: 0.13224628567695618
- * 4: 0.18096305429935455
+ * 1: 483.877919614315
+ * 2: 838.5848999023438
+ * 3: 1322.4628567695618
+ * 4: 1809.6305429935455
  */
 export class FPSClock {
     /**
@@ -26,7 +28,7 @@ export class FPSClock {
         let elapsedTime = 0
         const frames = data.frames.map((frameInfo: number[]) => {
             const retValue = elapsedTime
-            const delta = frameInfo[0]
+            const delta = frameInfo[0] * 1000
             elapsedTime += delta
             return retValue
         })
@@ -35,7 +37,9 @@ export class FPSClock {
 
     // Used to play "catch-up" in the delta function
     public currentFrame: number
-    private lastFrame: number
+    // private lastFrame: number
+
+    private lastTime: number
     private started: number
 
     // Represented as an index in the array to the elapsed time at that frame
@@ -48,10 +52,10 @@ export class FPSClock {
     constructor(frameToDuration: number[]) {
         this.frameToDuration = frameToDuration
         this.paused = true
-        this.started = performance.now()
-        this.lastFrame = this.currentFrame = 0
+        this.currentFrame = 0
+        this.lastTime = 0
         this.callback = []
-        this.timeout()
+        this.timeout(!this.paused)
     }
 
     public addCallback(callback: (frame: number) => void) {
@@ -61,16 +65,25 @@ export class FPSClock {
     public setFrame(frame: number) {
         // Prevent negative frames
         frame = frame < 0 ? 0 : frame
+        // Get that "little bit" of real time beyond the frame's saved time
+        const littleDiff = this.lastTime - this.started - (this.frameToDuration[this.currentFrame])
+        const frameDiff = this.frameToDuration[this.currentFrame] - this.frameToDuration[frame]
+        console.log(littleDiff)
+        // A lower frame means the animation needs to roll back, so the last time will become
+        // greater than current time, and thus the delta is negative
+        this.lastTime = performance.now() + frameDiff
+        this.started = this.lastTime - this.frameToDuration[frame] - littleDiff
         this.currentFrame = frame
-        this.started = performance.now() - (this.frameToDuration[this.currentFrame] * 1000)
-        for (const callback of this.callback) {
-            callback(frame)
-        }
+        this.doCallbacks()
     }
 
     public play() {
         if (this.paused) {
-            this.started = performance.now() - (this.frameToDuration[this.currentFrame] * 1000)
+            // First, find out how much "true time" has elapsed while paused
+            const now = performance.now()
+            const diff = this.lastTime - this.started
+            this.lastTime = now
+            this.started = now - diff
             this.paused = false
             this.timeout()
         }
@@ -81,35 +94,50 @@ export class FPSClock {
         this.timeout(false)
     }
 
+    public getElapsedTime() {
+        return (this.lastTime - this.started) / 1000
+    }
+
     /**
-     * Returns the number of millseconds elapsed since the last time getDelta was called. Note that
+     * Returns the number of seconds elapsed since the last time getDelta was called. Note that
      * this may not be the true time since getDelta was called but this is the elapsed "frame time",
      * that is, the elapsed time relative to the number of frames that have passed since last
      * calling this method.
      *
-     * @returns {number} milliseconds
+     * @returns {number} seconds
      */
     public getDelta(): number {
-        const now = this.frameToDuration[this.currentFrame]
-        const last = this.frameToDuration[this.lastFrame]
-        this.lastFrame = this.currentFrame
-        return now - last
+        const now = performance.now()
+        if (!this.lastTime) {
+            this.lastTime = now
+        }
+        const last = this.lastTime
+        this.lastTime = now
+        console.log("delta:", (now - last) / 1000)
+        return (now - last) / 1000
     }
 
     private readonly update = () => {
         if (!this.paused) {
-            this.getElapsedFrames()
-            for (const callback of this.callback) {
-                callback(this.currentFrame)
+            if (!this.started) {
+                this.started = this.lastTime
             }
+            this.getElapsedFrames()
+            this.doCallbacks()
         }
     }
 
     private getElapsedFrames() {
         const now = performance.now()
-        const elapsed = (now - this.started) / 1000
-        while (this.frameToDuration[this.currentFrame + 1] < elapsed) {
+        const secondsElapsed = (now - this.started)
+        while (this.frameToDuration[this.currentFrame + 1] < secondsElapsed) {
             this.currentFrame += 1
+        }
+    }
+
+    private doCallbacks() {
+        for (const callback of this.callback) {
+            callback(this.currentFrame)
         }
     }
 

--- a/webapp/src/Models/Replay/Clock.ts
+++ b/webapp/src/Models/Replay/Clock.ts
@@ -33,13 +33,13 @@ export class FPSClock {
         return new FPSClock(frames)
     }
 
+    // Used to play "catch-up" in the delta function
+    public currentFrame: number
+    private lastFrame: number
+    private started: number
+
     // Represented as an index in the array to the elapsed time at that frame
     private readonly frameToDuration: number[]
-
-    // Used to play "catch-up" in the delta function
-    private lastFrame: number
-    private currentFrame: number
-    private started: number
 
     private paused: boolean
     private animation: NodeJS.Timer


### PR DESCRIPTION
Adjustments to the clock produce real-time animations for in-between frame states. This new clock allows the same functionality as before but reduces the number of setState calls in the ReplayViewer component. This is to cut back on heap usage but it should be noted that if we plan on adding frame-based scrubbing, we should only allow Next/Previous frame. The existing scrubber should be ported over to a time-based scrubber (quite like the one in-game).