### PR TITLE
Fix browser history for search

### DIFF
--- a/webapp/src/Components/Shared/Search.tsx
+++ b/webapp/src/Components/Shared/Search.tsx
@@ -69,7 +69,7 @@ class SearchComponent extends React.PureComponent<Props, State> {
                     </div>
                 }
                 {this.state.resolvedId &&
-                <Redirect to={PLAYER_PAGE_LINK(this.state.resolvedId)}/>
+                <Redirect push to={PLAYER_PAGE_LINK(this.state.resolvedId)}/>
                 }
             </>
         )


### PR DESCRIPTION
Searching will now add a new route to the browser history so you can go back properly. Tested this locally and it's working.
Closes #227 