### PR TITLE
Allow all playlists for Progression Page

### DIFF
--- a/webapp/src/Components/Player/Compare/Progression/PlayerProgressionCharts.tsx
+++ b/webapp/src/Components/Player/Compare/Progression/PlayerProgressionCharts.tsx
@@ -95,7 +95,6 @@ export class PlayerProgressionCharts extends React.PureComponent<Props, State> {
                 inputLabel="Playlist"
                 helperText="Select playlist to use"
                 dropdownOnly
-                currentPlaylistsOnly
                 multiple={false}/>
         )
         return (


### PR DESCRIPTION
On the Progression Page the "Custom" playlist was not being displayed as an option, this PR is to remove the filter for this particular component.

## Steps
1. Go to the Compare page
1. Select the "Progression" tab
1. The "Custom" option should be displayed and selectable now

## Pictures
![image](https://user-images.githubusercontent.com/703220/52088504-a74ec400-2571-11e9-971c-d784468db015.png)
