### PR TITLE
Hide predictions tab if predictions do not exist

### DIFF
--- a/webapp/src/Components/Pages/ReplayPage.tsx
+++ b/webapp/src/Components/Pages/ReplayPage.tsx
@@ -60,11 +60,6 @@ export class ReplayPage extends React.PureComponent<Props, State> {
         )
     }
 
-    // private readonly getReplay = (): Promise<void> => {
-    //     return Promise.all([getReplay(this.props.match.params.id), getExplanations()])
-    //         .then((replay) => this.setState({replay: replay[0], explanations: replay[1]}))
-    // }
-
     private readonly getBoth = async() => {
         return Promise.all([getReplay(this.props.match.params.id), getExplanations()]).then(
             (data) => this.setState({ replay: data[0], explanations: data[1] })

--- a/webapp/src/Components/Pages/ReplayPage.tsx
+++ b/webapp/src/Components/Pages/ReplayPage.tsx
@@ -16,7 +16,7 @@ type Props = RouteComponentProps<RouteParams>
 interface State {
     replay?: Replay
     explanations?: Record<string, any> | undefined
-    predictedRanks?: any
+    predictedRanks?: Predictions
 }
 
 export class ReplayPage extends React.PureComponent<Props, State> {
@@ -25,30 +25,35 @@ export class ReplayPage extends React.PureComponent<Props, State> {
         this.state = {}
     }
 
+    public componentDidMount() {
+        this.getPredictedRanks()
+    }
+
     public render() {
         const matchUrl = this.props.match.url
-        const {replay, explanations, predictedRanks} = this.state
+        const { replay, explanations, predictedRanks } = this.state
 
         return (
             <BasePage backgroundImage={"/replay_page_background.png"}>
-                <Grid container spacing={24} justify="center" style={{minHeight: "100%"}}>
+                <Grid container spacing={24} justify="center" style={{ minHeight: "100%" }}>
                     <LoadableWrapper load={this.getBoth}>
-                        {replay &&
-                        <Switch>
-                            <Route
-                                exact path={matchUrl}
-                                render={() => (
-                                    <ReplayView
-                                        replay={replay}
-                                        predictedRanks={predictedRanks}
-                                        explanations={explanations}
-                                        handleUpdateTags={this.handleUpdateTags}
-                                    />
-                                )}
-                            />
-                            <Redirect from="*" to={matchUrl}/>
-                        </Switch>
-                        }
+                        {replay && (
+                            <Switch>
+                                <Route
+                                    exact
+                                    path={matchUrl}
+                                    render={() => (
+                                        <ReplayView
+                                            replay={replay}
+                                            predictedRanks={predictedRanks}
+                                            explanations={explanations}
+                                            handleUpdateTags={this.handleUpdateTags}
+                                        />
+                                    )}
+                                />
+                                <Redirect from="*" to={matchUrl} />
+                            </Switch>
+                        )}
                     </LoadableWrapper>
                 </Grid>
             </BasePage>
@@ -60,22 +65,24 @@ export class ReplayPage extends React.PureComponent<Props, State> {
     //         .then((replay) => this.setState({replay: replay[0], explanations: replay[1]}))
     // }
 
-    private readonly getBoth = (): Promise<void> => {
+    private readonly getBoth = async() => {
         // TODO: when predictions 404, don't show the tab (?)
-        return Promise.all([getReplay(this.props.match.params.id), getPredictedRanks(this.props.match.params.id),
-            getExplanations()])
-            .then((data) => this.setState({replay: data[0], predictedRanks: data[1], explanations: data[2]}))
+        return Promise.all([getReplay(this.props.match.params.id), getExplanations()]).then(
+            (data) => this.setState({ replay: data[0], explanations: data[1] })
+        )
     }
-    // private getPredictedRanks = (): Promise<void> => {
-    //     return getPredictedRanks(this.props.match.params.id)
-    //         .then((predictedRanks) => this.setState({predictedRanks}))
-    // }
+
+    private readonly getPredictedRanks = async() => {
+        return getPredictedRanks(this.props.match.params.id).then((predictedRanks) =>
+            this.setState({ predictedRanks })
+        )
+    }
 
     private readonly handleUpdateTags = (tags: Tag[]) => {
         const replay = {
             ...this.state.replay!,
             tags
         }
-        this.setState({replay})
+        this.setState({ replay })
     }
 }

--- a/webapp/src/Components/Pages/ReplayPage.tsx
+++ b/webapp/src/Components/Pages/ReplayPage.tsx
@@ -66,7 +66,6 @@ export class ReplayPage extends React.PureComponent<Props, State> {
     // }
 
     private readonly getBoth = async() => {
-        // TODO: when predictions 404, don't show the tab (?)
         return Promise.all([getReplay(this.props.match.params.id), getExplanations()]).then(
             (data) => this.setState({ replay: data[0], explanations: data[1] })
         )

--- a/webapp/src/Components/Replay/BasicStats/PlayerStats/PlayerStatsTabs.tsx
+++ b/webapp/src/Components/Replay/BasicStats/PlayerStats/PlayerStatsTabs.tsx
@@ -40,7 +40,7 @@ class PlayerStatsTabsComponent extends React.PureComponent<Props> {
             <Tabs value={this.props.selectedTab}
                   onChange={this.props.handleChange}
                   centered
-                  scrollable={isWidthDown("xs", this.props.width)}
+                  variant={isWidthDown("xs", this.props.width) ? "scrollable" : "fullWidth"}
                   scrollButtons={isWidthDown("xs", this.props.width) ? "on" : undefined}
             >
                 {Object.keys(PlayerStatsSubcategory).map((subcategory) => {

--- a/webapp/src/Components/Replay/ReplayTabs.tsx
+++ b/webapp/src/Components/Replay/ReplayTabs.tsx
@@ -12,15 +12,19 @@ import { ReplayViewer } from "./ReplayViewer/ReplayViewer"
 
 interface OwnProps {
     replay: Replay
-    predictedRanks: any
+    predictedRanks?: Predictions
     explanations: Record<string, any> | undefined
 }
 
-type Props = OwnProps
-    & ReturnType<typeof mapStateToProps>
-    & WithWidth
+type Props = OwnProps & ReturnType<typeof mapStateToProps> & WithWidth
 
-type ReplayTab = "playerStats" | "teamStats" | "advancedStats" | "replayViewer" | "predictions" | "qrCode"
+type ReplayTab =
+    | "playerStats"
+    | "teamStats"
+    | "advancedStats"
+    | "replayViewer"
+    | "predictions"
+    | "qrCode"
 
 interface State {
     selectedTab: ReplayTab
@@ -29,72 +33,87 @@ interface State {
 class ReplayTabsComponent extends React.PureComponent<Props, State> {
     constructor(props: Props) {
         super(props)
-        this.state = {selectedTab: "playerStats"}
+        this.state = { selectedTab: "playerStats" }
     }
 
     public render() {
-        const {predictedRanks} = this.props
+        const { loggedInUser, predictedRanks } = this.props
+        const { selectedTab } = this.state
         const isWidthSm = isWidthDown("sm", this.props.width)
         const url = `https://calculated.gg/replays/${this.props.replay.id}`
         const qrcode = (
             <CardContent>
                 <Grid container justify="center" alignContent="center" spacing={32}>
-                    <Grid item xs={12} style={{textAlign: "center"}}>
-                        <QRCode value={url}/>
+                    <Grid item xs={12} style={{ textAlign: "center" }}>
+                        <QRCode value={url} />
                     </Grid>
 
-                    <Grid item xs={12} style={{textAlign: "center"}}>
+                    <Grid item xs={12} style={{ textAlign: "center" }}>
                         <Typography>{url}</Typography>
                     </Grid>
 
-                    <Grid item xs={12} style={{textAlign: "center"}}>
-                        <Typography>Use this with the AR Replay Viewer mobile app to view this replay in Augmented
-                            Reality!</Typography>
+                    <Grid item xs={12} style={{ textAlign: "center" }}>
+                        <Typography>
+                            Use this with the AR Replay Viewer mobile app to view this replay in
+                            Augmented Reality!
+                        </Typography>
                     </Grid>
                 </Grid>
             </CardContent>
         )
         return (
-            <Card square style={{width: "100%"}}>
-                <Tabs value={this.state.selectedTab}
-                      onChange={this.handleSelectTab}
-                      centered={!isWidthSm}
-                      scrollable={isWidthSm}
+            <Card square style={{ width: "100%" }}>
+                <Tabs
+                    value={selectedTab}
+                    onChange={this.handleSelectTab}
+                    centered={!isWidthSm}
+                    variant={isWidthSm ? "scrollable" : "fullWidth"}
                 >
-                    <Tab key="basicStats" label="Player Stats" value="playerStats"/>
-                    <Tab key="predictions" label="Predictions" value="predictions"/>
-                    {this.props.loggedInUser && this.props.loggedInUser.beta &&
-                    <Tab key="teamStats" label="Team Stats" value="teamStats"/>
-                    }
-                    {this.props.loggedInUser && this.props.loggedInUser.alpha &&
-                    [
-                        <Tab key="advancedStats" label="Advanced Stats" value="advancedStats"/>,
-                        <Tab key="replayViewer" label="Replay Viewer" value="replayViewer"/>
-                    ]
-                    }
+                    <Tab key="basicStats" label="Player Stats" value="playerStats" />
+                    {predictedRanks && (
+                        <Tab key="predictions" label="Predictions" value="predictions" />
+                    )}
+                    {loggedInUser && loggedInUser.beta && (
+                        <Tab key="teamStats" label="Team Stats" value="teamStats" />
+                    )}
+                    {loggedInUser &&
+                        loggedInUser.alpha && [
+                            <Tab
+                                key="advancedStats"
+                                label="Advanced Stats"
+                                value="advancedStats"
+                            />,
+                            <Tab key="replayViewer" label="Replay Viewer" value="replayViewer" />
+                        ]}
 
-                    <Tab key="qrCode" label="QR Code" value="qrCode"/>
+                    <Tab key="qrCode" label="QR Code" value="qrCode" />
                 </Tabs>
-                {this.state.selectedTab === "playerStats" &&
-                <PlayerStatsContent replay={this.props.replay} explanations={this.props.explanations} />
-                }
-                {this.state.selectedTab === "predictions" &&
-                <PredictionsContent replay={this.props.replay} predictedRanks={predictedRanks}/>
-                }
-                {this.state.selectedTab === "teamStats" &&
-                <TeamStatsContent replay={this.props.replay} explanations={this.props.explanations}/>
-                }
-                {this.state.selectedTab === "replayViewer" &&
-                <ReplayViewer replay={this.props.replay}/>
-                }
-                {this.state.selectedTab === "qrCode" &&
-                qrcode}
+                {selectedTab === "playerStats" && (
+                    <PlayerStatsContent
+                        replay={this.props.replay}
+                        explanations={this.props.explanations}
+                    />
+                )}
+                {selectedTab === "predictions" && (
+                    <PredictionsContent
+                        replay={this.props.replay}
+                        predictedRanks={predictedRanks}
+                    />
+                )}
+                {selectedTab === "teamStats" && (
+                    <TeamStatsContent
+                        replay={this.props.replay}
+                        explanations={this.props.explanations}
+                    />
+                )}
+                {selectedTab === "replayViewer" && <ReplayViewer replay={this.props.replay} />}
+                {selectedTab === "qrCode" && qrcode}
             </Card>
         )
     }
 
     private readonly handleSelectTab = (_: React.ChangeEvent<{}>, selectedTab: ReplayTab) => {
-        this.setState({selectedTab})
+        this.setState({ selectedTab })
     }
 }
 

--- a/webapp/src/Components/Replay/ReplayTeamCard/ReplayTeamCard.tsx
+++ b/webapp/src/Components/Replay/ReplayTeamCard/ReplayTeamCard.tsx
@@ -1,4 +1,13 @@
-import { Card, CardContent, CardHeader, createStyles, Divider, List, WithStyles, withStyles } from "@material-ui/core"
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    createStyles,
+    Divider,
+    List,
+    WithStyles,
+    withStyles
+} from "@material-ui/core"
 import * as React from "react"
 import { Replay } from "../../../Models"
 import { TeamCardPlayer } from "./TeamCardPlayer"
@@ -6,15 +15,14 @@ import { TeamCardPlayer } from "./TeamCardPlayer"
 interface OwnProps {
     replay: Replay
     isOrange: boolean
-    predictedRanks: any
+    predictedRanks: Predictions
 }
 
-type Props = OwnProps
-    & WithStyles<typeof styles>
+type Props = OwnProps & WithStyles<typeof styles>
 
 class ReplayTeamCardComponent extends React.PureComponent<Props> {
     public render() {
-        const {replay, isOrange, classes, predictedRanks} = this.props
+        const { replay, isOrange, classes, predictedRanks } = this.props
 
         const title = isOrange ? "Orange" : "Blue"
         const headerClassName = isOrange ? classes.orangeCard : classes.blueCard
@@ -23,16 +31,21 @@ class ReplayTeamCardComponent extends React.PureComponent<Props> {
             <Card square>
                 <CardHeader
                     title={title}
-                    titleTypographyProps={{align: "center"}}
-                    className={headerClassName}/>
-                <Divider/>
+                    titleTypographyProps={{ align: "center" }}
+                    className={headerClassName}
+                />
+                <Divider />
                 <CardContent>
                     <List>
                         {replay.players
                             .filter((player) => player.isOrange === isOrange)
-                            .map((player) => <TeamCardPlayer player={player} predictedRank={predictedRanks[player.id]}
-                                                             key={player.id}/>)
-                        }
+                            .map((player) => (
+                                <TeamCardPlayer
+                                    player={player}
+                                    predictedRank={predictedRanks[player.id]}
+                                    key={player.id}
+                                />
+                            ))}
                     </List>
                 </CardContent>
             </Card>

--- a/webapp/src/Components/Replay/ReplayView.tsx
+++ b/webapp/src/Components/Replay/ReplayView.tsx
@@ -1,4 +1,12 @@
-import { Card, CardContent, CardHeader, Grid, IconButton, Tooltip, withWidth } from "@material-ui/core"
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    Grid,
+    IconButton,
+    Tooltip,
+    withWidth
+} from "@material-ui/core"
 import { isWidthUp, WithWidth } from "@material-ui/core/withWidth"
 import ArrowDownward from "@material-ui/icons/ArrowDownward"
 import CloudDownload from "@material-ui/icons/CloudDownload"
@@ -15,25 +23,25 @@ interface OwnProps {
     replay: Replay
     explanations: Record<string, any> | undefined
     handleUpdateTags: (tags: Tag[]) => void
-    predictedRanks: any
+    predictedRanks?: Predictions
 }
 
-type Props = OwnProps
-    & WithWidth
+type Props = OwnProps & WithWidth
 
 class ReplayViewComponent extends React.PureComponent<Props> {
     public render() {
-        const {width, replay, explanations, predictedRanks} = this.props
-        const blueCard = <ReplayTeamCard replay={replay} predictedRanks={predictedRanks} isOrange={false}/>
-        const orangeCard = <ReplayTeamCard replay={replay} predictedRanks={predictedRanks} isOrange={true}/>
+        const { width, replay, explanations, predictedRanks } = this.props
+        const blueCard = predictedRanks && (
+            <ReplayTeamCard replay={replay} predictedRanks={predictedRanks} isOrange={false} />
+        )
+        const orangeCard = predictedRanks && (
+            <ReplayTeamCard replay={replay} predictedRanks={predictedRanks} isOrange={true} />
+        )
 
         const downloadButton = (
             <Tooltip title="Download replay">
-                <IconButton
-                    href={LOCAL_LINK + `/api/replay/${replay.id}/download`}
-                    download
-                >
-                    <CloudDownload/>
+                <IconButton href={LOCAL_LINK + `/api/replay/${replay.id}/download`} download>
+                    <CloudDownload />
                 </IconButton>
             </Tooltip>
         )
@@ -44,31 +52,33 @@ class ReplayViewComponent extends React.PureComponent<Props> {
                     href={LOCAL_LINK + `/api/replay/${replay.id}/basic_player_stats/download`}
                     download
                 >
-                    <ArrowDownward/>
+                    <ArrowDownward />
                 </IconButton>
             </Tooltip>
-
         )
 
         const replayChartCard = (
             <Card>
                 <CardHeader
                     title={replay.name ? replay.name : "Unnamed replay"}
-                    subheader={<ColouredGameScore replay={replay}/>}
-                    titleTypographyProps={{align: "center"}}
-                    subheaderTypographyProps={{align: "center", variant: "subheading"}}
+                    subheader={<ColouredGameScore replay={replay} />}
+                    titleTypographyProps={{ align: "center" }}
+                    subheaderTypographyProps={{ align: "center", variant: "subheading" }}
                     action={
-                        <div style={{position: "relative", width: 0, right: 16, top: 16}}>
-                            <div style={{display: "flex", float: "right"}}>
-                                <TagDialogWrapper replay={replay} handleUpdateTags={this.props.handleUpdateTags}/>
+                        <div style={{ position: "relative", width: 0, right: 16, top: 16 }}>
+                            <div style={{ display: "flex", float: "right" }}>
+                                <TagDialogWrapper
+                                    replay={replay}
+                                    handleUpdateTags={this.props.handleUpdateTags}
+                                />
                                 {isWidthUp("sm", width) && dataExportButton}
-                                {isWidthUp("sm", width) && downloadButton
-                                }
+                                {isWidthUp("sm", width) && downloadButton}
                             </div>
-                        </div>}
+                        </div>
+                    }
                 />
-                <CardContent style={{overflowX: "auto"}}>
-                    <ReplayChart replay={replay}/>
+                <CardContent style={{ overflowX: "auto" }}>
+                    <ReplayChart replay={replay} />
                 </CardContent>
             </Card>
         )
@@ -90,21 +100,25 @@ class ReplayViewComponent extends React.PureComponent<Props> {
 
         return (
             <Grid item xs={12} container spacing={24} alignItems="center">
-                {isWidthUp("lg", width) ?
+                {isWidthUp("lg", width) ? (
                     <>
                         {blueGridItem}
                         {replayChartGridItem}
                         {orangeGridItem}
                     </>
-                    :
+                ) : (
                     <>
                         {blueGridItem}
                         {orangeGridItem}
                         {replayChartGridItem}
                     </>
-                }
+                )}
                 <Grid item xs={12}>
-                    <ReplayTabs replay={replay} explanations={explanations} predictedRanks={predictedRanks}/>
+                    <ReplayTabs
+                        replay={replay}
+                        explanations={explanations}
+                        predictedRanks={predictedRanks}
+                    />
                 </Grid>
             </Grid>
         )

--- a/webapp/src/Models/types/Predictions.d.ts
+++ b/webapp/src/Models/types/Predictions.d.ts
@@ -1,0 +1,1 @@
+type Predictions = { [playerId: number]: number }

--- a/webapp/tslint.json
+++ b/webapp/tslint.json
@@ -22,6 +22,7 @@
         "interface-name": false,
         "jsx-alignment": false,
         "jsx-boolean-value": false,
+        "jsx-curly-spacing": false,
         "jsx-no-lambda": false,
         "jsx-no-multiline-js": false,
         "jsx-space-before-trailing-slash": false,
@@ -47,7 +48,14 @@
         "no-var-keyword": true,
         "no-void-expression": [true, "ignore-arrow-function-shorthand"],
         "object-literal-sort-keys": false,
-        "one-line": [true, "check-catch", "check-else", "check-finally", "check-open-brace", "check-whitespace"],
+        "one-line": [
+            true,
+            "check-catch",
+            "check-else",
+            "check-finally",
+            "check-open-brace",
+            "check-whitespace"
+        ],
         "only-arrow-functions": true,
         "ordered-imports": true,
         "prefer-conditional-expression": false,
@@ -57,10 +65,13 @@
         "quotemark": [true, "double", "avoid-escape", "jsx-double"],
         "semicolon": [true, "never"],
         "space-before-function-paren": [true, "never"],
-        "trailing-comma": [true, {
-            "multiline": "never",
-            "singleline": "never"
-        }],
+        "trailing-comma": [
+            true,
+            {
+                "multiline": "never",
+                "singleline": "never"
+            }
+        ],
         "variable-name": [true, "ban-keywords", "check-format", "allow-pascal-case"],
         "whitespace": [
             true,


### PR DESCRIPTION
As the title states, this PR hides all hints of the predictions tab if we aren't able to pull the predictions in (404 error). 