### PR TITLE
#348: use git hash for app version

### DIFF
--- a/backend/initial_setup.py
+++ b/backend/initial_setup.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import shutil
+import subprocess
 from typing import Dict, List, Tuple
 
 from flask import Flask, render_template, g, request, redirect, send_from_directory
@@ -194,7 +195,8 @@ class CalculatedServer:
     @classmethod
     def get_version(cls):
         try:
-            # TODO use some sort of git lookup to get information
-            return "0.0.1"
-        except:
-            return "0.0.1"
+            return subprocess.check_output([
+                'git', 'rev-parse', '--short', 'HEAD'
+            ]).decode().strip()
+        except subprocess.CalledProcessError:
+            return 'unknown'

--- a/tests/server_tests/backend_utils_tests/initial_setup_test.py
+++ b/tests/server_tests/backend_utils_tests/initial_setup_test.py
@@ -4,7 +4,7 @@ from backend.initial_setup import CalculatedServer
 
 
 class Test_initial_setup:
-    def test_get_version(self, test_client):
+    def test_get_version(self):
         # git needs to be in the environment for this
         assert re.compile(r"[0-9a-fA-F]{7}").match(
             CalculatedServer.get_version()

--- a/tests/server_tests/backend_utils_tests/initial_setup_test.py
+++ b/tests/server_tests/backend_utils_tests/initial_setup_test.py
@@ -1,0 +1,11 @@
+import re
+
+from backend.initial_setup import CalculatedServer
+
+
+class Test_initial_setup:
+    def test_get_version(self, test_client):
+        # git needs to be in the environment for this
+        assert re.compile(r"[0-9a-fA-F]{7}").match(
+            CalculatedServer.get_version()
+        )


### PR DESCRIPTION
Use the git hash for the app `VERSION` field. This will work on any system, as long as they have `git` in their path. If it doesn't work, nothing will break anyway, it will just use the version `'unknown'`. I tested that the expected commit hash is getting loaded into the VERSION field,