### PR TITLE
casting tooltipItem.xLabel to string in ReplayChart HorizontalBar

### DIFF
--- a/webapp/src/Components/Replay/ReplayChart.tsx
+++ b/webapp/src/Components/Replay/ReplayChart.tsx
@@ -113,7 +113,7 @@ export class ReplayChart extends React.PureComponent<Props> {
             tooltips: {
                 callbacks: {
                     label: (tooltipItem, data) => data.datasets![tooltipItem.datasetIndex!].label + ": " +
-                        Math.abs(parseInt(tooltipItem.xLabel!, 10))
+                        Math.abs(parseInt(tooltipItem.xLabel!.toString(), 10))
                 }
             },
             maintainAspectRatio: false


### PR DESCRIPTION
I followed the docker setup instructions and were welcomed by an error like this:

![screenshot-localhost_3000-2019 10 23-22_53_24](https://user-images.githubusercontent.com/9142942/67435116-be47b180-f5eb-11e9-8a0d-7ad36d1bd6f4.png)

this `.toString()` fixes the type issue, but I'm not sure if this is solving only the symptom, not the cause, will dig deeper on another occasion.

just to be sure here is my setup
```
$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 18.04.2 LTS
Release:        18.04
Codename:       bionic
$ uname -r
4.15.0-65-generic
$ docker -v
Docker version 18.06.1-ce, build e68fc7a
```