### PR TITLE
Reducing front app weight by code-splitting on react router

### DIFF
--- a/.travis/tslint.sh
+++ b/.travis/tslint.sh
@@ -7,7 +7,7 @@ NC='\033[0m'
 echo "Running Linters:"
 
 # Run tslint and get the output and return code
-tslint=$(webapp/node_modules/tslint/bin/tslint --project webapp -c webapp/tslint.test.json)
+tslint=$(cd webapp; npm run tslint-check)
 ret_code=$?
 
 # If it didn't pass, announce it failed and print the output

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1342,6 +1342,12 @@
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
             "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
         },
+        "@sheerun/mutationobserver-shim": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
+            "integrity": "sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==",
+            "dev": true
+        },
         "@svgr/babel-plugin-add-jsx-attribute": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz",
@@ -1449,6 +1455,48 @@
                 "@svgr/plugin-jsx": "^4.3.2",
                 "@svgr/plugin-svgo": "^4.3.1",
                 "loader-utils": "^1.2.3"
+            }
+        },
+        "@testing-library/dom": {
+            "version": "6.8.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-6.8.1.tgz",
+            "integrity": "sha512-b+Q4wryafqsSTFBV14cc5xqhN/OVB9oMeUQvZwy1kVx+kdqs4zQAcyvCsFkdcqx7NxibWpUN/fBIUaqyAEhitw==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.6.2",
+                "@sheerun/mutationobserver-shim": "^0.3.2",
+                "@types/testing-library__dom": "^6.0.0",
+                "aria-query": "3.0.0",
+                "pretty-format": "^24.9.0",
+                "wait-for-expect": "^3.0.0"
+            }
+        },
+        "@testing-library/jest-dom": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-4.2.0.tgz",
+            "integrity": "sha512-H61OmRhGPWLrj9emyISx0qjp8jvC9RWyRniuLAq75Ny5XfPiOvWfnY3Wm2Tf0HXusX+PG40I94Gw792IAtSKKg==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.5.1",
+                "chalk": "^2.4.1",
+                "css": "^2.2.3",
+                "css.escape": "^1.5.1",
+                "jest-diff": "^24.0.0",
+                "jest-matcher-utils": "^24.0.0",
+                "lodash": "^4.17.11",
+                "pretty-format": "^24.0.0",
+                "redent": "^3.0.0"
+            }
+        },
+        "@testing-library/react": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-9.3.0.tgz",
+            "integrity": "sha512-FTPCwmLo0tLtP50Au2uGz4/N1BcJTnBx4StDVHZ47zPMEj1/+J2rk/RTj8SLoHRKWCtcmhN4wRmudOXQNP29/w==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.6.0",
+                "@testing-library/dom": "^6.3.0",
+                "@types/testing-library__react": "^9.1.0"
             }
         },
         "@types/babel__core": {
@@ -1959,6 +2007,25 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
             "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="
+        },
+        "@types/testing-library__dom": {
+            "version": "6.5.3",
+            "resolved": "https://registry.npmjs.org/@types/testing-library__dom/-/testing-library__dom-6.5.3.tgz",
+            "integrity": "sha512-E/LSnbzo25gCLy/YOHKY9KJ+rfI8hy5cfbScyZqVuFw9CUMn1faWEDnxMcVHgjAbWtTStfllB8TwNKCx8bAKeA==",
+            "dev": true,
+            "requires": {
+                "pretty-format": "^24.3.0"
+            }
+        },
+        "@types/testing-library__react": {
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/@types/testing-library__react/-/testing-library__react-9.1.2.tgz",
+            "integrity": "sha512-CYaMqrswQ+cJACy268jsLAw355DZtPZGt3Jwmmotlcu8O/tkoXBI6AeZ84oZBJsIsesozPKzWzmv/0TIU+1E9Q==",
+            "dev": true,
+            "requires": {
+                "@types/react-dom": "*",
+                "@types/testing-library__dom": "*"
+            }
         },
         "@types/yargs": {
             "version": "13.0.3",
@@ -4053,6 +4120,12 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
             "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
+        },
+        "css.escape": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+            "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+            "dev": true
         },
         "cssdb": {
             "version": "4.4.0",
@@ -6247,7 +6320,8 @@
                         },
                         "ansi-regex": {
                             "version": "2.1.1",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "aproba": {
                             "version": "1.2.0",
@@ -6265,11 +6339,13 @@
                         },
                         "balanced-match": {
                             "version": "1.0.0",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "brace-expansion": {
                             "version": "1.1.11",
                             "bundled": true,
+                            "optional": true,
                             "requires": {
                                 "balanced-match": "^1.0.0",
                                 "concat-map": "0.0.1"
@@ -6282,15 +6358,18 @@
                         },
                         "code-point-at": {
                             "version": "1.1.0",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "concat-map": {
                             "version": "0.0.1",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "console-control-strings": {
                             "version": "1.1.0",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "core-util-is": {
                             "version": "1.0.2",
@@ -6393,7 +6472,8 @@
                         },
                         "inherits": {
                             "version": "2.0.3",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "ini": {
                             "version": "1.3.5",
@@ -6403,6 +6483,7 @@
                         "is-fullwidth-code-point": {
                             "version": "1.0.0",
                             "bundled": true,
+                            "optional": true,
                             "requires": {
                                 "number-is-nan": "^1.0.0"
                             }
@@ -6415,17 +6496,20 @@
                         "minimatch": {
                             "version": "3.0.4",
                             "bundled": true,
+                            "optional": true,
                             "requires": {
                                 "brace-expansion": "^1.1.7"
                             }
                         },
                         "minimist": {
                             "version": "0.0.8",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "minipass": {
                             "version": "2.3.5",
                             "bundled": true,
+                            "optional": true,
                             "requires": {
                                 "safe-buffer": "^5.1.2",
                                 "yallist": "^3.0.0"
@@ -6442,6 +6526,7 @@
                         "mkdirp": {
                             "version": "0.5.1",
                             "bundled": true,
+                            "optional": true,
                             "requires": {
                                 "minimist": "0.0.8"
                             }
@@ -6514,7 +6599,8 @@
                         },
                         "number-is-nan": {
                             "version": "1.0.1",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "object-assign": {
                             "version": "4.1.1",
@@ -6524,6 +6610,7 @@
                         "once": {
                             "version": "1.4.0",
                             "bundled": true,
+                            "optional": true,
                             "requires": {
                                 "wrappy": "1"
                             }
@@ -6599,7 +6686,8 @@
                         },
                         "safe-buffer": {
                             "version": "5.1.2",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
@@ -6629,6 +6717,7 @@
                         "string-width": {
                             "version": "1.0.2",
                             "bundled": true,
+                            "optional": true,
                             "requires": {
                                 "code-point-at": "^1.0.0",
                                 "is-fullwidth-code-point": "^1.0.0",
@@ -6646,6 +6735,7 @@
                         "strip-ansi": {
                             "version": "3.0.1",
                             "bundled": true,
+                            "optional": true,
                             "requires": {
                                 "ansi-regex": "^2.0.0"
                             }
@@ -6684,11 +6774,13 @@
                         },
                         "wrappy": {
                             "version": "1.0.2",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "yallist": {
                             "version": "3.0.3",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         }
                     }
                 },
@@ -7540,6 +7632,12 @@
                 "symbol-observable": "1.2.0"
             }
         },
+        "indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "dev": true
+        },
         "indexes-of": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
@@ -8208,7 +8306,8 @@
                         },
                         "ansi-regex": {
                             "version": "2.1.1",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "aproba": {
                             "version": "1.2.0",
@@ -8573,7 +8672,8 @@
                         },
                         "safe-buffer": {
                             "version": "5.1.2",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
@@ -8621,6 +8721,7 @@
                         "strip-ansi": {
                             "version": "3.0.1",
                             "bundled": true,
+                            "optional": true,
                             "requires": {
                                 "ansi-regex": "^2.0.0"
                             }
@@ -8659,11 +8760,13 @@
                         },
                         "wrappy": {
                             "version": "1.0.2",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "yallist": {
                             "version": "3.0.3",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         }
                     }
                 },
@@ -9930,6 +10033,12 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
             "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+        },
+        "min-indent": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
+            "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
+            "dev": true
         },
         "mini-css-extract-plugin": {
             "version": "0.8.0",
@@ -12448,6 +12557,16 @@
                 "minimatch": "3.0.4"
             }
         },
+        "redent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+            "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+            "dev": true,
+            "requires": {
+                "indent-string": "^4.0.0",
+                "strip-indent": "^3.0.0"
+            }
+        },
         "reduce-reducers": {
             "version": "0.4.3",
             "resolved": "https://registry.npmjs.org/reduce-reducers/-/reduce-reducers-0.4.3.tgz",
@@ -13852,6 +13971,15 @@
             "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
             "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
         },
+        "strip-indent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+            "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+            "dev": true,
+            "requires": {
+                "min-indent": "^1.0.0"
+            }
+        },
         "strip-json-comments": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
@@ -14705,6 +14833,12 @@
                 "xml-name-validator": "^3.0.0"
             }
         },
+        "wait-for-expect": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.1.tgz",
+            "integrity": "sha512-3Ha7lu+zshEG/CeHdcpmQsZnnZpPj/UsG3DuKO8FskjuDbkx3jE3845H+CuwZjA2YWYDfKMU2KhnCaXMLd3wVw==",
+            "dev": true
+        },
         "walker": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
@@ -14827,7 +14961,8 @@
                         },
                         "ansi-regex": {
                             "version": "2.1.1",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "aproba": {
                             "version": "1.2.0",
@@ -14839,8 +14974,8 @@
                             "bundled": true,
                             "optional": true,
                             "requires": {
-                                "delegates": "^1.0.0",
-                                "readable-stream": "^2.0.6"
+                                "delegates": "1.0.0",
+                                "readable-stream": "2.3.6"
                             }
                         },
                         "balanced-match": {
@@ -14910,7 +15045,7 @@
                             "bundled": true,
                             "optional": true,
                             "requires": {
-                                "minipass": "^2.2.1"
+                                "minipass": "2.3.5"
                             }
                         },
                         "fs.realpath": {
@@ -14923,14 +15058,14 @@
                             "bundled": true,
                             "optional": true,
                             "requires": {
-                                "aproba": "^1.0.3",
-                                "console-control-strings": "^1.0.0",
-                                "has-unicode": "^2.0.0",
-                                "object-assign": "^4.1.0",
-                                "signal-exit": "^3.0.0",
-                                "string-width": "^1.0.1",
-                                "strip-ansi": "^3.0.1",
-                                "wide-align": "^1.1.0"
+                                "aproba": "1.2.0",
+                                "console-control-strings": "1.1.0",
+                                "has-unicode": "2.0.1",
+                                "object-assign": "4.1.1",
+                                "signal-exit": "3.0.2",
+                                "string-width": "1.0.2",
+                                "strip-ansi": "3.0.1",
+                                "wide-align": "1.1.3"
                             }
                         },
                         "glob": {
@@ -14938,12 +15073,12 @@
                             "bundled": true,
                             "optional": true,
                             "requires": {
-                                "fs.realpath": "^1.0.0",
-                                "inflight": "^1.0.4",
-                                "inherits": "2",
-                                "minimatch": "^3.0.4",
-                                "once": "^1.3.0",
-                                "path-is-absolute": "^1.0.0"
+                                "fs.realpath": "1.0.0",
+                                "inflight": "1.0.6",
+                                "inherits": "2.0.3",
+                                "minimatch": "3.0.4",
+                                "once": "1.4.0",
+                                "path-is-absolute": "1.0.1"
                             }
                         },
                         "has-unicode": {
@@ -14972,8 +15107,8 @@
                             "bundled": true,
                             "optional": true,
                             "requires": {
-                                "once": "^1.3.0",
-                                "wrappy": "1"
+                                "once": "1.4.0",
+                                "wrappy": "1.0.2"
                             }
                         },
                         "inherits": {
@@ -15009,14 +15144,16 @@
                         },
                         "minimist": {
                             "version": "0.0.8",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "minipass": {
                             "version": "2.3.5",
                             "bundled": true,
+                            "optional": true,
                             "requires": {
-                                "safe-buffer": "^5.1.2",
-                                "yallist": "^3.0.0"
+                                "safe-buffer": "5.1.2",
+                                "yallist": "3.0.3"
                             }
                         },
                         "minizlib": {
@@ -15024,12 +15161,13 @@
                             "bundled": true,
                             "optional": true,
                             "requires": {
-                                "minipass": "^2.2.1"
+                                "minipass": "2.3.5"
                             }
                         },
                         "mkdirp": {
                             "version": "0.5.1",
                             "bundled": true,
+                            "optional": true,
                             "requires": {
                                 "minimist": "0.0.8"
                             }
@@ -15094,10 +15232,10 @@
                             "bundled": true,
                             "optional": true,
                             "requires": {
-                                "are-we-there-yet": "~1.1.2",
-                                "console-control-strings": "~1.1.0",
-                                "gauge": "~2.7.3",
-                                "set-blocking": "~2.0.0"
+                                "are-we-there-yet": "1.1.5",
+                                "console-control-strings": "1.1.0",
+                                "gauge": "2.7.4",
+                                "set-blocking": "2.0.0"
                             }
                         },
                         "number-is-nan": {
@@ -15115,7 +15253,7 @@
                             "bundled": true,
                             "optional": true,
                             "requires": {
-                                "wrappy": "1"
+                                "wrappy": "1.0.2"
                             }
                         },
                         "os-homedir": {
@@ -15152,10 +15290,10 @@
                             "bundled": true,
                             "optional": true,
                             "requires": {
-                                "deep-extend": "^0.6.0",
-                                "ini": "~1.3.0",
-                                "minimist": "^1.2.0",
-                                "strip-json-comments": "~2.0.1"
+                                "deep-extend": "0.6.0",
+                                "ini": "1.3.5",
+                                "minimist": "1.2.0",
+                                "strip-json-comments": "2.0.1"
                             },
                             "dependencies": {
                                 "minimist": {
@@ -15170,13 +15308,13 @@
                             "bundled": true,
                             "optional": true,
                             "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.3",
-                                "isarray": "~1.0.0",
-                                "process-nextick-args": "~2.0.0",
-                                "safe-buffer": "~5.1.1",
-                                "string_decoder": "~1.1.1",
-                                "util-deprecate": "~1.0.1"
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.3",
+                                "isarray": "1.0.0",
+                                "process-nextick-args": "2.0.0",
+                                "safe-buffer": "5.1.2",
+                                "string_decoder": "1.1.1",
+                                "util-deprecate": "1.0.2"
                             }
                         },
                         "rimraf": {
@@ -15184,12 +15322,13 @@
                             "bundled": true,
                             "optional": true,
                             "requires": {
-                                "glob": "^7.1.3"
+                                "glob": "7.1.3"
                             }
                         },
                         "safe-buffer": {
                             "version": "5.1.2",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
@@ -15221,9 +15360,9 @@
                             "bundled": true,
                             "optional": true,
                             "requires": {
-                                "code-point-at": "^1.0.0",
-                                "is-fullwidth-code-point": "^1.0.0",
-                                "strip-ansi": "^3.0.0"
+                                "code-point-at": "1.1.0",
+                                "is-fullwidth-code-point": "1.0.0",
+                                "strip-ansi": "3.0.1"
                             }
                         },
                         "string_decoder": {
@@ -15237,8 +15376,9 @@
                         "strip-ansi": {
                             "version": "3.0.1",
                             "bundled": true,
+                            "optional": true,
                             "requires": {
-                                "ansi-regex": "^2.0.0"
+                                "ansi-regex": "2.1.1"
                             }
                         },
                         "strip-json-comments": {
@@ -15251,13 +15391,13 @@
                             "bundled": true,
                             "optional": true,
                             "requires": {
-                                "chownr": "^1.1.1",
-                                "fs-minipass": "^1.2.5",
-                                "minipass": "^2.3.4",
-                                "minizlib": "^1.1.1",
-                                "mkdirp": "^0.5.0",
-                                "safe-buffer": "^5.1.2",
-                                "yallist": "^3.0.2"
+                                "chownr": "1.1.1",
+                                "fs-minipass": "1.2.5",
+                                "minipass": "2.3.5",
+                                "minizlib": "1.2.1",
+                                "mkdirp": "0.5.1",
+                                "safe-buffer": "5.1.2",
+                                "yallist": "3.0.3"
                             }
                         },
                         "util-deprecate": {
@@ -15270,16 +15410,18 @@
                             "bundled": true,
                             "optional": true,
                             "requires": {
-                                "string-width": "^1.0.2 || 2"
+                                "string-width": "1.0.2"
                             }
                         },
                         "wrappy": {
                             "version": "1.0.2",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "yallist": {
                             "version": "3.0.3",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         }
                     }
                 },
@@ -15613,7 +15755,8 @@
                         },
                         "ansi-regex": {
                             "version": "2.1.1",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "aproba": {
                             "version": "1.2.0",
@@ -15631,11 +15774,13 @@
                         },
                         "balanced-match": {
                             "version": "1.0.0",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "brace-expansion": {
                             "version": "1.1.11",
                             "bundled": true,
+                            "optional": true,
                             "requires": {
                                 "balanced-match": "^1.0.0",
                                 "concat-map": "0.0.1"
@@ -15648,15 +15793,18 @@
                         },
                         "code-point-at": {
                             "version": "1.1.0",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "concat-map": {
                             "version": "0.0.1",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "console-control-strings": {
                             "version": "1.1.0",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "core-util-is": {
                             "version": "1.0.2",
@@ -15759,7 +15907,8 @@
                         },
                         "inherits": {
                             "version": "2.0.3",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "ini": {
                             "version": "1.3.5",
@@ -15769,6 +15918,7 @@
                         "is-fullwidth-code-point": {
                             "version": "1.0.0",
                             "bundled": true,
+                            "optional": true,
                             "requires": {
                                 "number-is-nan": "^1.0.0"
                             }
@@ -15781,17 +15931,20 @@
                         "minimatch": {
                             "version": "3.0.4",
                             "bundled": true,
+                            "optional": true,
                             "requires": {
                                 "brace-expansion": "^1.1.7"
                             }
                         },
                         "minimist": {
                             "version": "0.0.8",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "minipass": {
                             "version": "2.3.5",
                             "bundled": true,
+                            "optional": true,
                             "requires": {
                                 "safe-buffer": "^5.1.2",
                                 "yallist": "^3.0.0"
@@ -15808,6 +15961,7 @@
                         "mkdirp": {
                             "version": "0.5.1",
                             "bundled": true,
+                            "optional": true,
                             "requires": {
                                 "minimist": "0.0.8"
                             }
@@ -15880,7 +16034,8 @@
                         },
                         "number-is-nan": {
                             "version": "1.0.1",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "object-assign": {
                             "version": "4.1.1",
@@ -15890,6 +16045,7 @@
                         "once": {
                             "version": "1.4.0",
                             "bundled": true,
+                            "optional": true,
                             "requires": {
                                 "wrappy": "1"
                             }
@@ -15965,7 +16121,8 @@
                         },
                         "safe-buffer": {
                             "version": "5.1.2",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
@@ -15995,6 +16152,7 @@
                         "string-width": {
                             "version": "1.0.2",
                             "bundled": true,
+                            "optional": true,
                             "requires": {
                                 "code-point-at": "^1.0.0",
                                 "is-fullwidth-code-point": "^1.0.0",
@@ -16012,6 +16170,7 @@
                         "strip-ansi": {
                             "version": "3.0.1",
                             "bundled": true,
+                            "optional": true,
                             "requires": {
                                 "ansi-regex": "^2.0.0"
                             }
@@ -16050,11 +16209,13 @@
                         },
                         "wrappy": {
                             "version": "1.0.2",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         },
                         "yallist": {
                             "version": "3.0.3",
-                            "bundled": true
+                            "bundled": true,
+                            "optional": true
                         }
                     }
                 },

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -50,6 +50,8 @@
         "tslint-prettier-check": "tslint-config-prettier-check ./tslint.json"
     },
     "devDependencies": {
+        "@testing-library/jest-dom": "^4.2.0",
+        "@testing-library/react": "^9.3.0",
         "@types/chart.js": "^2.7.33",
         "@types/jest": "^24.0.13",
         "@types/lodash": "^4.14.116",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -47,7 +47,7 @@
         "build": "react-scripts build",
         "test": "react-scripts src/test --env=jsdom",
         "eject": "react-scripts eject",
-        "tslint-prettier-check": "tslint-config-prettier-check ./tslint.json"
+        "tslint-check": "tslint --project . -c ./tslint.test.json"
     },
     "devDependencies": {
         "@testing-library/jest-dom": "^4.2.0",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,27 +1,13 @@
 import { createStyles, WithStyles, withStyles } from "@material-ui/core"
 import * as React from "react"
 import { BrowserRouter, Redirect, Route, Switch } from "react-router-dom"
+
 import { AppListener } from "./AppListener"
-import { AboutPage } from "./Components/Pages/AboutPage"
-import { AdminPage } from "./Components/Pages/AdminPage"
-import { DocumentationPage } from "./Components/Pages/DocumentationPage"
-import { ExplanationsPage } from "./Components/Pages/ExplanationsPage"
-import { GlobalStatsPage } from "./Components/Pages/GlobalStatsPage"
+import { codeSplit } from "./CodeSplitComponent"
 import { HomePage } from "./Components/Pages/HomePage"
-import { ItemsStatsPage } from "./Components/Pages/ItemStatsPage"
-import { LeaderboardsPage } from "./Components/Pages/LeaderboardsPage"
-import { PlayerComparePage } from "./Components/Pages/PlayerComparePage"
 import { PlayerPage } from "./Components/Pages/PlayerPage"
-import { PluginsPage } from "./Components/Pages/PluginsPage"
-import { PrivacyPolicyPage } from "./Components/Pages/PrivacyPolicyPage"
-import { ReplayPage } from "./Components/Pages/ReplayPage"
-import { ReplaysGroupPage } from "./Components/Pages/ReplaysGroupPage"
-import { ReplaysSearchPage } from "./Components/Pages/ReplaysSearchPage"
-import { StatusPage } from "./Components/Pages/StatusPage"
-import { TagsPage } from "./Components/Pages/TagsPage"
-import { TrainingPackPage } from "./Components/Pages/TrainingPackPage"
-import { UploadPage } from "./Components/Pages/UploadPage"
 import { Notifications } from "./Components/Shared/Notification/Notifications"
+
 import {
     ABOUT_LINK, ADMIN_LINK, DOCUMENTATION_LINK,
     EXPLANATIONS_LINK,
@@ -36,6 +22,24 @@ import {
     TRAINING_LINK,
     UPLOAD_LINK
 } from "./Globals"
+
+const CodeSplitAboutPage = codeSplit(() => import("./Components/Pages/AboutPage"), "AboutPage")
+const CodeSplitAdminPage = codeSplit(() => import("./Components/Pages/AdminPage"), "AdminPage")
+const CodeSplitDocumentationPage = codeSplit(() => import("./Components/Pages/DocumentationPage"), "DocumentationPage")
+const CodeSplitExplanationsPage = codeSplit(() => import("./Components/Pages/ExplanationsPage"), "ExplanationsPage")
+const CodeSplitGlobalStatsPage = codeSplit(() => import("./Components/Pages/GlobalStatsPage"), "GlobalStatsPage")
+const CodeSplitItemsStatsPage = codeSplit(() => import("./Components/Pages/ItemStatsPage"), "ItemStatsPage")
+const CodeSplitLeaderboardsPage = codeSplit(() => import("./Components/Pages/LeaderboardsPage"), "LeaderboardsPage")
+const CodeSplitPlayerComparePage = codeSplit(() => import("./Components/Pages/PlayerComparePage"), "PlayerComparePage")
+const CodeSplitPluginsPage = codeSplit(() => import("./Components/Pages/PluginsPage"), "PluginsPage")
+const CodeSplitPrivacyPolicyPage = codeSplit(() => import("./Components/Pages/PrivacyPolicyPage"), "PrivacyPolicyPage")
+const CodeSplitReplayPage = codeSplit(() => import("./Components/Pages/ReplayPage"), "ReplayPage")
+const CodeSplitReplaysGroupPage = codeSplit(() => import("./Components/Pages/ReplaysGroupPage"), "ReplaysGroupPage")
+const CodeSplitReplaysSearchPage = codeSplit(() => import("./Components/Pages/ReplaysSearchPage"), "ReplaysSearchPage")
+const CodeSplitStatusPage = codeSplit(() => import("./Components/Pages/StatusPage"), "StatusPage")
+const CodeSplitTagsPage = codeSplit(() => import("./Components/Pages/TagsPage"), "TagsPage")
+const CodeSplitTrainingPackPage = codeSplit(() => import("./Components/Pages/TrainingPackPage"), "TrainingPackPage")
+const CodeSplitUploadPage = codeSplit(() => import("./Components/Pages/UploadPage"), "UploadPage")
 
 const styles = createStyles({
     App: {
@@ -59,24 +63,24 @@ class AppComponent extends React.Component<Props> {
                             <Redirect exact from={"/players/overview/:id"} to={PLAYER_PAGE_LINK(":id")}/>
                             <Redirect exact from={"/replays/parsed/view/:id"} to={REPLAY_PAGE_LINK(":id")}/>
                             <Route exact path="/" component={HomePage}/>
-                            <Route path={ADMIN_LINK} component={AdminPage}/>
-                            <Route path={ITEMS_LINK} component={ItemsStatsPage}/>
-                            <Route path={TRAINING_LINK} component={TrainingPackPage}/>
-                            <Route path={LEADERBOARDS_LINK} component={LeaderboardsPage}/>
+                            <Route path={ADMIN_LINK} component={CodeSplitAdminPage}/>
+                            <Route path={ITEMS_LINK} component={CodeSplitItemsStatsPage}/>
+                            <Route path={TRAINING_LINK} component={CodeSplitTrainingPackPage}/>
+                            <Route path={LEADERBOARDS_LINK} component={CodeSplitLeaderboardsPage}/>
                             <Route path={PLAYER_PAGE_LINK(":id")} component={PlayerPage}/>
-                            <Route path={PLAYER_COMPARE_PAGE_LINK} component={PlayerComparePage}/>
-                            <Route path={REPLAY_PAGE_LINK(":id")} component={ReplayPage}/>
-                            <Route path={REPLAYS_GROUP_PAGE_LINK} component={ReplaysGroupPage}/>
-                            <Route path={REPLAYS_SEARCH_PAGE_LINK()} component={ReplaysSearchPage}/>
-                            <Route exact path={ABOUT_LINK} component={AboutPage}/>
-                            <Route exact path={UPLOAD_LINK} component={UploadPage}/>
-                            <Route exact path={GLOBAL_STATS_LINK} component={GlobalStatsPage}/>
-                            <Route exact path={PLUGINS_LINK} component={PluginsPage}/>
-                            <Route exact path={STATUS_PAGE_LINK} component={StatusPage}/>
-                            <Route exact path={EXPLANATIONS_LINK} component={ExplanationsPage}/>
-                            <Route exact path={DOCUMENTATION_LINK} component={DocumentationPage}/>
-                            <Route exact path={PRIVACY_POLICY_LINK} component={PrivacyPolicyPage}/>
-                            <Route exact path={TAGS_PAGE_LINK} component={TagsPage}/>
+                            <Route path={PLAYER_COMPARE_PAGE_LINK} component={CodeSplitPlayerComparePage}/>
+                            <Route path={REPLAY_PAGE_LINK(":id")} component={CodeSplitReplayPage}/>
+                            <Route path={REPLAYS_GROUP_PAGE_LINK} component={CodeSplitReplaysGroupPage}/>
+                            <Route path={REPLAYS_SEARCH_PAGE_LINK()} component={CodeSplitReplaysSearchPage}/>
+                            <Route exact path={ABOUT_LINK} component={CodeSplitAboutPage}/>
+                            <Route exact path={UPLOAD_LINK} component={CodeSplitUploadPage}/>
+                            <Route exact path={GLOBAL_STATS_LINK} component={CodeSplitGlobalStatsPage}/>
+                            <Route exact path={PLUGINS_LINK} component={CodeSplitPluginsPage}/>
+                            <Route exact path={STATUS_PAGE_LINK} component={CodeSplitStatusPage}/>
+                            <Route exact path={EXPLANATIONS_LINK} component={CodeSplitExplanationsPage}/>
+                            <Route exact path={DOCUMENTATION_LINK} component={CodeSplitDocumentationPage}/>
+                            <Route exact path={PRIVACY_POLICY_LINK} component={CodeSplitPrivacyPolicyPage}/>
+                            <Route exact path={TAGS_PAGE_LINK} component={CodeSplitTagsPage}/>
                             {/*Redirect unknowns to root*/}
                             <Redirect from="*" to="/"/>
                         </Switch>

--- a/webapp/src/CodeSplitComponent.tsx
+++ b/webapp/src/CodeSplitComponent.tsx
@@ -1,0 +1,35 @@
+import React, { Component, ComponentType } from "react"
+
+type Props = any
+
+interface State {
+  component: ComponentType | null
+}
+
+export const codeSplit = (importComponent: () => Promise<any>, importKey: string) => {
+  class AsyncComponent extends Component<Props, State> {
+    constructor(props: Props) {
+      super(props)
+
+      this.state = {
+        component: null
+      }
+    }
+
+    public async componentDidMount() {
+      const importedModule = await importComponent()
+
+      this.setState({
+        component: importedModule[importKey]
+      })
+    }
+
+    public render() {
+      const C = this.state.component
+
+      return C ? <C {...this.props} /> : null
+    }
+  }
+
+  return AsyncComponent
+}

--- a/webapp/src/CodeSplitComponent.tsx
+++ b/webapp/src/CodeSplitComponent.tsx
@@ -1,8 +1,13 @@
 import React, { Component, ComponentType } from "react"
 
+import {
+    Typography
+} from "@material-ui/core"
+
 type Props = any
 
 interface State {
+  errorOnDynamicLoad: boolean,
   component: ComponentType | null
 }
 
@@ -12,20 +17,37 @@ export const codeSplit = (importComponent: () => Promise<any>, importKey: string
       super(props)
 
       this.state = {
+        errorOnDynamicLoad: false,
         component: null
       }
     }
 
     public async componentDidMount() {
-      const importedModule = await importComponent()
+      try {
+        const importedModule = await importComponent()
 
-      this.setState({
-        component: importedModule[importKey]
-      })
+        this.setState({
+          component: importedModule[importKey]
+        })
+      } catch (error) {
+        console.error(error)
+
+        this.setState({
+          errorOnDynamicLoad: true
+        })
+      }
     }
 
     public render() {
-      const C = this.state.component
+      const {errorOnDynamicLoad, component : C} = this.state
+
+      if (errorOnDynamicLoad) {
+        return (
+          <Typography>
+            Error loading {importKey}. Please check your network connection and reload this page.
+          </Typography>
+        )
+      }
 
       return C ? <C {...this.props} /> : null
     }

--- a/webapp/src/CodeSplitComponent.tsx
+++ b/webapp/src/CodeSplitComponent.tsx
@@ -30,8 +30,6 @@ export const codeSplit = (importComponent: () => Promise<any>, importKey: string
           component: importedModule[importKey]
         })
       } catch (error) {
-        console.error(error)
-
         this.setState({
           errorOnDynamicLoad: true
         })

--- a/webapp/src/Components/Player/Overview/MatchHistory/OverviewMatchHistory.tsx
+++ b/webapp/src/Components/Player/Overview/MatchHistory/OverviewMatchHistory.tsx
@@ -20,6 +20,7 @@ interface State {
 export class OverviewMatchHistory extends React.PureComponent<Props, State> {
     constructor(props: Props) {
         super(props)
+
         this.state = {
             reloadSignal: false,
             page: 0,

--- a/webapp/src/test/App.test.tsx
+++ b/webapp/src/test/App.test.tsx
@@ -1,9 +1,0 @@
-import * as React from "react"
-import * as ReactDOM from "react-dom"
-import { App } from "../App"
-
-it("renders without crashing", () => {
-    const div = document.createElement("div")
-    ReactDOM.render(<App/>, div)
-    ReactDOM.unmountComponentAtNode(div)
-})

--- a/webapp/src/test/CodeSplitComponent.test.tsx
+++ b/webapp/src/test/CodeSplitComponent.test.tsx
@@ -1,0 +1,18 @@
+import "@testing-library/jest-dom/extend-expect"
+import { render } from "@testing-library/react"
+import * as React from "react"
+
+import { codeSplit } from "../CodeSplitComponent"
+
+it("should render error information if async import fails", async() => {
+  // given
+  const Component = codeSplit(() => Promise.reject("any error on dynamic import"), "AboutPage")
+
+  // when
+  const { findByText } = render(<Component />)
+
+  // then
+  expect(await findByText(
+    "Error loading AboutPage. Please check your network connection and reload this page."
+  )).toBeInTheDocument()
+})


### PR DESCRIPTION
I went for a quick win for the JS downloaded to the client.

In the main chunk are left HomePage and PlayerPage, I thought these might be pages that people use most of the time. Do you have data to base that decision off of? I think it could be either PlayerPage or ReplayPage. 

Maybe only HomePage could be left in main chunk, what do you think? 
What is the most common path for the users?

production build results:

before (master):
```
  503.48 KB  build/static/js/7.6a19d7b2.chunk.js
  48.97 KB   build/static/js/main.d030a72c.chunk.js <----
  1.25 KB    build/static/js/runtime-main.3ad18d4d.js
  183 B      build/static/js/Octane_ZXR_Blue.1df26457.chunk.js
  182 B      build/static/js/Octane_ZXR_Orange.0bc9a006.chunk.js
  174 B      build/static/js/Wheel.b91c372b.chunk.js
  173 B      build/static/js/Field.f57c7537.chunk.js
  172 B      build/static/js/Ball.0e2e9528.chunk.js
  156 B      build/static/css/main.c451d4cb.chunk.css
```

after (this branch):
```
  284.94 KB  build/static/js/8.1cefc500.chunk.js
  175.66 KB  build/static/js/0.e56dde60.chunk.js
  43.43 KB   build/static/js/9.7ee2dfe7.chunk.js
  31.14 KB   build/static/js/main.c7a9b88b.chunk.js <----
  7.41 KB    build/static/js/14.2ae0d0a4.chunk.js
  4.77 KB    build/static/js/12.6dbb579c.chunk.js
  4.69 KB    build/static/js/13.e4ed6c94.chunk.js
  4.38 KB    build/static/js/10.72010d7b.chunk.js
  4.32 KB    build/static/js/11.30195956.chunk.js
  4.22 KB    build/static/js/15.eb6f673b.chunk.js
  1.9 KB     build/static/js/16.f1b17fc7.chunk.js
  1.84 KB    build/static/js/17.75d37bf5.chunk.js
  1.8 KB     build/static/js/19.a252525c.chunk.js
  1.58 KB    build/static/js/22.f7bd2645.chunk.js
  1.5 KB     build/static/js/24.5b9c88e6.chunk.js
  1.42 KB    build/static/js/runtime-main.a40531c2.js
  1.16 KB    build/static/js/18.8f78b2d2.chunk.js
  1.16 KB    build/static/js/23.dd63fd39.chunk.js
  1.01 KB    build/static/js/20.3e82debb.chunk.js
  759 B      build/static/js/21.f6f20830.chunk.js
  544 B      build/static/js/25.140d37f8.chunk.js
  534 B      build/static/js/26.e545b972.chunk.js
  182 B      build/static/js/Octane_ZXR_Blue.27e4abee.chunk.js
  182 B      build/static/js/Octane_ZXR_Orange.08d14efc.chunk.js
  173 B      build/static/js/Field.f1f999fc.chunk.js
  173 B      build/static/js/Wheel.dea7108a.chunk.js
  173 B      build/static/js/Ball.52160155.chunk.js
  156 B      build/static/css/main.c451d4cb.chunk.css
```

this reduces the main chunk in size by ~ 36% with relatively low work done, and realistically most users are not going to interact with 'about us' pages, so there is no point in downloading it