### PR TITLE
Patreon widget failed because class changed

### DIFF
--- a/backend/blueprints/spa_api/service_layers/homepage/patreon.py
+++ b/backend/blueprints/spa_api/service_layers/homepage/patreon.py
@@ -5,6 +5,10 @@ from bs4 import BeautifulSoup
 
 from backend.database.startup import lazy_get_redis
 
+try:
+    from config import PATREON_PROGRESS_LOOKUP_CLASS
+except ImportError:
+    PATREON_PROGRESS_LOOKUP_CLASS = "sc-gZMcBi fXaIeo"
 
 class PatreonProgress:
     def __init__(self, progress: str, total: str):
@@ -24,7 +28,7 @@ class PatreonProgress:
                 return tuple(json.loads(r.get('patreon_progress')))
         r = requests.get("https://patreon.com/calculated")
         bs = BeautifulSoup(r.text, "html.parser")
-        progress = bs.find_all(class_="sc-htpNat ebhhXb")[0].text
+        progress = bs.find_all(class_=PATREON_PROGRESS_LOOKUP_CLASS)[0].text
         nums = [int(n[1:]) for n in progress.split(' of ')]
         if lazy_get_redis() is not None:
             r = lazy_get_redis()

--- a/webapp/src/Components/Home/Widgets/Patreon.tsx
+++ b/webapp/src/Components/Home/Widgets/Patreon.tsx
@@ -30,38 +30,41 @@ export class Patreon extends React.Component<Props, State> {
     public render() {
         return (
             <Card style={this.props.style}>
-                <CardHeader title={"Patreon Goal Progress"}
-                subheader={"100% of contributions go to server costs"}/>
+                <CardHeader
+                    title={"Patreon Goal Progress"}
+                    subheader={"100% of contributions go to server costs"}
+                />
                 <CardContent>
                     {this.state.patreonProgress ? (
                         <>
                             <div style={{marginBottom: "15px"}}>
                                 <Typography variant="h5" className="tex2jax_ignore">
-                                  ${this.state.patreonProgress.progress} /
-                                  ${this.state.patreonProgress.total}
+                                    ${this.state.patreonProgress.progress} /
+                                    ${this.state.patreonProgress.total}
                                 </Typography>
                             </div>
                             <Grid item xs={12}>
                                 <LinearProgress variant="determinate"
                                                 value={this.state.patreonProgress.progress /
-                                                this.state.patreonProgress.total * 100.0}/>
+                                                this.state.patreonProgress.total * 100.0} />
                             </Grid>
+                        </>
+                    ) : null}
 
-                            <Grid item xs={12} container justify="flex-end">
-                                <a
-                                    href={PATREON_LINK}
-                                    target="_blank"
-                                    rel="noreferrer noopener"
-                                    style={{textDecoration: "none"}}
-                                >
-                                    <Button variant="text" size="small">
-                                        <Typography variant="subtitle1">
-                                            Support us
-                                        </Typography>
-                                    </Button>
-                                </a>
-                            </Grid>
-                        </>) : null}
+                    <Grid item xs={12} container justify="flex-end">
+                        <a
+                            href={PATREON_LINK}
+                            target="_blank"
+                            rel="noreferrer noopener"
+                            style={{textDecoration: "none"}}
+                        >
+                            <Button variant="text" size="small">
+                                <Typography variant="subtitle1">
+                                    Support us
+                                </Typography>
+                            </Button>
+                        </a>
+                    </Grid>
                 </CardContent>
 
             </Card>

--- a/webapp/src/Components/Home/Widgets/Patreon.tsx
+++ b/webapp/src/Components/Home/Widgets/Patreon.tsx
@@ -3,6 +3,8 @@ import Card from "@material-ui/core/Card"
 import CardContent from "@material-ui/core/CardContent"
 import LinearProgress from "@material-ui/core/LinearProgress"
 import * as React from "react"
+
+import { PATREON_LINK } from "../../../Globals"
 import { PatreonResponse } from "../../../Models/types/Homepage"
 import { getPatreonProgress } from "../../../Requests/Home"
 
@@ -34,8 +36,10 @@ export class Patreon extends React.Component<Props, State> {
                     {this.state.patreonProgress ? (
                         <>
                             <div style={{marginBottom: "15px"}}>
-                                <Typography variant="h5">${this.state.patreonProgress.progress} /
-                                    ${this.state.patreonProgress.total}</Typography>
+                                <Typography variant="h5" className="tex2jax_ignore">
+                                  ${this.state.patreonProgress.progress} /
+                                  ${this.state.patreonProgress.total}
+                                </Typography>
                             </div>
                             <Grid item xs={12}>
                                 <LinearProgress variant="determinate"
@@ -45,14 +49,14 @@ export class Patreon extends React.Component<Props, State> {
 
                             <Grid item xs={12} container justify="flex-end">
                                 <a
-                                    href={"https://patreon.com/calculated"}
+                                    href={PATREON_LINK}
                                     target="_blank"
                                     rel="noreferrer noopener"
                                     style={{textDecoration: "none"}}
                                 >
                                     <Button variant="text" size="small">
                                         <Typography variant="subtitle1">
-                                            Link
+                                            Support us
                                         </Typography>
                                     </Button>
                                 </a>


### PR DESCRIPTION
Patreon updated their site in one way or another and the class that is used for screen-scraping has changed.

I added a config option read for `PATREON_PROGRESS_LOOKUP_CLASS` with a default to the current class. This is good enough for now, but if this class changes more often maybe [using their api](https://docs.patreon.com/#python) should be considered

minor improvements:
- added a class to ignore mathjax transformations, because it stripped `$` signs and it didn't look like currency
- changed 'link' to 'support us', because it sounds better as a call to action
- link shows up even if progress lookup fails
- used patreon link from globals

renders OK now:
![screenshot-localhost_3000-2019 10 27-16_01_38](https://user-images.githubusercontent.com/9142942/67636803-8cc53380-f8d4-11e9-9342-2604430b0f2b.png)

and if progress lookup fails:
![screenshot-localhost_3000-2019 10 27-16_12_05](https://user-images.githubusercontent.com/9142942/67636804-9353ab00-f8d4-11e9-800d-d0186196ee82.png)