### PR TITLE
Enable GZIP compression of all responses

### DIFF
--- a/backend/initial_setup.py
+++ b/backend/initial_setup.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Tuple
 
 from flask import Flask, g, request, redirect, send_from_directory
 from flask import session as flask_session
+from flask_compress import Compress
 from flask_cors import CORS
 from flask_httpauth import HTTPBasicAuth
 from prometheus_client import make_wsgi_app, multiprocess, CollectorRegistry
@@ -59,6 +60,9 @@ class CalculatedServer:
         CalculatedServer.set_up_app_config(app)
         CORS(app)
         CalculatedServer.create_needed_folders(app)
+
+        # Enable GZIP compression
+        Compress(app)
 
         session_factory = lazy_startup()
 

--- a/imports_test.py
+++ b/imports_test.py
@@ -8,7 +8,7 @@ class TestImports:
 
     global_allowed_imports = ['sqlalchemy', 'RLBotServer', 'carball', 'flask', 'redis', 'gzip',
                               'flask_cors', 'werkzeug', 'bs4', 'torch', 'pandas', 'numpy',
-                              'prometheus_client', 'Crypto', 'flask_httpauth']
+                              'prometheus_client', 'Crypto', 'flask_httpauth', 'flask_compress']
     test_imports = ['alchemy_mock', 'fakeredis', 'responses']
 
     black_list = ['utils']

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ arrow==0.12.1
 Babel==2.6.0
 beautifulsoup4==4.7.1
 billiard==3.6
-carball
+carball==0.6.34
 celery==4.3
 certifi==2018.8.24
 chardet==3.0.4
@@ -11,6 +11,7 @@ click==6.7
 cycler==0.10.0
 Flask==1.0.2
 Flask-Celery-Helper==1.1.0
+Flask-Compress==1.4.0
 Flask-Cors==3.0.6
 Flask-Login==0.4.1
 flower==0.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ arrow==0.12.1
 Babel==2.6.0
 beautifulsoup4==4.7.1
 billiard==3.6
-carball==0.6.34
+carball
 celery==4.3
 certifi==2018.8.24
 chardet==3.0.4


### PR DESCRIPTION
Here's a sample before/after of a compressed `/replay/<id>/positions` response:
![image](https://user-images.githubusercontent.com/10366495/70381959-93a68380-1921-11ea-97fc-57f9efd33694.png)
![image](https://user-images.githubusercontent.com/10366495/70381963-9903ce00-1921-11ea-9837-4ec5abfa7c9a.png)
