### PR TITLE
Render date in local format

### DIFF
--- a/webapp/src/Components/Player/Overview/MatchHistory/ReplayExpansionPanelSummary.tsx
+++ b/webapp/src/Components/Player/Overview/MatchHistory/ReplayExpansionPanelSummary.tsx
@@ -70,7 +70,7 @@ class ReplayExpansionPanelSummaryComponent extends React.PureComponent<Props> {
         const typographyVariant = "subtitle1"
 
         const {replay, player} = this.props
-        const dateFormat = isWidthUp("lg", width) ? "DD/MM/YYYY" : "DD/MM"
+        const dateFormat = isWidthUp("lg", width) ? "L" : "DD/MM"
         const replayName = sanitizeProfanity(replay.name)
         const replayDate = (
             <Tooltip title={replay.date.format("LLLL")} enterDelay={200} placement="bottom-start">


### PR DESCRIPTION
I love the replay overview--but the date _always_ catches me off guard. This renders in format `MM/DD/YYYY` or `DD/MM/YYYY` depending on the locale