### PR TITLE
Fix: errors caused by unused shebangs in mac scripts

### DIFF
--- a/mac_run.sh
+++ b/mac_run.sh
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 echo ************************** REDIS *************************
 redis-server &
 sleep 2

--- a/mac_stop.sh
+++ b/mac_stop.sh
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 redis-cli shutdown &
 pg_ctl -D /usr/local/var/postgres stop &
 pkill flower


### PR DESCRIPTION
These are not Python scripts so it would error when the subsequent bash statement was evaluated

![image](https://user-images.githubusercontent.com/1146921/95116018-0207ce00-070c-11eb-8f8b-54a54b0cc38a.png)

![image](https://user-images.githubusercontent.com/1146921/95115980-f4eadf00-070b-11eb-98e5-d70aee4efe48.png)
